### PR TITLE
feat: implement menu according to the role (V1-015)

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -5,13 +5,14 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "frontend",
       "version": "0.1.0",
       "dependencies": {
         "@emotion/react": "^11.7.1",
         "@emotion/styled": "^11.6.0",
         "@material-ui/core": "^4.12.3",
         "@mui/core": "^5.0.0-alpha.54",
-        "@mui/icons-material": "^5.2.4",
+        "@mui/icons-material": "^5.2.5",
         "@mui/material": "^5.2.4",
         "@mui/styles": "^5.2.3",
         "@testing-library/jest-dom": "^5.16.1",
@@ -3353,7 +3354,8 @@
     "node_modules/@types/history": {
       "version": "4.7.9",
       "resolved": "https://registry.npmjs.org/@types/history/-/history-4.7.9.tgz",
-      "integrity": "sha512-MUc6zSmU3tEVnkQ78q0peeEjKWPUADMlC/t++2bI8WnAG2tvYRPIgHG8lWkXwqc8MsUF6Z2MOf+Mh5sazOmhiQ=="
+      "integrity": "sha512-MUc6zSmU3tEVnkQ78q0peeEjKWPUADMlC/t++2bI8WnAG2tvYRPIgHG8lWkXwqc8MsUF6Z2MOf+Mh5sazOmhiQ==",
+      "dev": true
     },
     "node_modules/@types/hoist-non-react-statics": {
       "version": "3.3.1",
@@ -3500,6 +3502,7 @@
       "version": "5.1.17",
       "resolved": "https://registry.npmjs.org/@types/react-router/-/react-router-5.1.17.tgz",
       "integrity": "sha512-RNSXOyb3VyRs/EOGmjBhhGKTbnN6fHWvy5FNLzWfOWOGjgVUKqJZXfpKzLmgoU8h6Hj8mpALj/mbXQASOb92wQ==",
+      "dev": true,
       "dependencies": {
         "@types/history": "*",
         "@types/react": "*"
@@ -3509,6 +3512,7 @@
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/@types/react-router-dom/-/react-router-dom-5.3.2.tgz",
       "integrity": "sha512-ELEYRUie2czuJzaZ5+ziIp9Hhw+juEw8b7C11YNA4QdLCVbQ3qLi2l4aq8XnlqM7V31LZX8dxUuFUCrzHm6sqQ==",
+      "dev": true,
       "dependencies": {
         "@types/history": "*",
         "@types/react": "*",
@@ -7561,17 +7565,6 @@
         "node": "^10.12.0 || >=12.0.0"
       }
     },
-    "node_modules/eslint-config-react-app": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-config-react-app/-/eslint-config-react-app-6.0.0.tgz",
-      "integrity": "sha512-bpoAAC+YRfzq0dsTk+6v9aHm/uqnDwayNAXleMypGl6CpxI9oXXscVHo4fk3eJPIn+rsbtNetB4r/ZIidFIE8A==",
-      "dependencies": {
-        "confusing-browser-globals": "^1.0.10"
-      },
-      "engines": {
-        "node": "^10.12.0 || >=12.0.0"
-      }
-    },
     "node_modules/eslint-import-resolver-node": {
       "version": "0.3.6",
       "resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.6.tgz",
@@ -11511,24 +11504,6 @@
         "node": ">= 10.14.2"
       }
     },
-    "node_modules/jest-resolve": {
-      "version": "26.6.0",
-      "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-26.6.0.tgz",
-      "integrity": "sha512-tRAz2bwraHufNp+CCmAD8ciyCpXCs1NQxB5EJAmtCFy6BN81loFEGWKzYu26Y62lAJJe4X4jg36Kf+NsQyiStQ==",
-      "dependencies": {
-        "@jest/types": "^26.6.0",
-        "chalk": "^4.0.0",
-        "graceful-fs": "^4.2.4",
-        "jest-pnp-resolver": "^1.2.2",
-        "jest-util": "^26.6.0",
-        "read-pkg-up": "^7.0.1",
-        "resolve": "^1.17.0",
-        "slash": "^3.0.0"
-      },
-      "engines": {
-        "node": ">= 10.14.2"
-      }
-    },
     "node_modules/jest-resolve-dependencies": {
       "version": "26.6.3",
       "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-26.6.3.tgz",
@@ -11540,64 +11515,6 @@
       },
       "engines": {
         "node": ">= 10.14.2"
-      }
-    },
-    "node_modules/jest-resolve/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/jest-resolve/node_modules/chalk": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/jest-resolve/node_modules/color-convert": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dependencies": {
-        "color-name": "~1.1.4"
-      },
-      "engines": {
-        "node": ">=7.0.0"
-      }
-    },
-    "node_modules/jest-resolve/node_modules/color-name": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
-    },
-    "node_modules/jest-resolve/node_modules/has-flag": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/jest-resolve/node_modules/supports-color": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/jest-runner": {
@@ -18919,6 +18836,228 @@
       },
       "engines": {
         "node": "^10.12.0 || >=12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^5.0.0 || ^6.0.0 || ^7.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-scripts/node_modules/@typescript-eslint/scope-manager": {
+      "version": "4.33.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-4.33.0.tgz",
+      "integrity": "sha512-5IfJHpgTsTZuONKbODctL4kKuQje/bzBRkwHE8UOZ4f89Zeddg+EGZs8PD8NcN4LdM3ygHWYB3ukPAYjvl/qbQ==",
+      "dependencies": {
+        "@typescript-eslint/types": "4.33.0",
+        "@typescript-eslint/visitor-keys": "4.33.0"
+      },
+      "engines": {
+        "node": "^8.10.0 || ^10.13.0 || >=11.10.1"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/react-scripts/node_modules/@typescript-eslint/types": {
+      "version": "4.33.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-4.33.0.tgz",
+      "integrity": "sha512-zKp7CjQzLQImXEpLt2BUw1tvOMPfNoTAfb8l51evhYbOEEzdWyQNmHWWGPR6hwKJDAi+1VXSBmnhL9kyVTTOuQ==",
+      "engines": {
+        "node": "^8.10.0 || ^10.13.0 || >=11.10.1"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/react-scripts/node_modules/@typescript-eslint/typescript-estree": {
+      "version": "4.33.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-4.33.0.tgz",
+      "integrity": "sha512-rkWRY1MPFzjwnEVHsxGemDzqqddw2QbTJlICPD9p9I9LfsO8fdmfQPOX3uKfUaGRDFJbfrtm/sXhVXN4E+bzCA==",
+      "dependencies": {
+        "@typescript-eslint/types": "4.33.0",
+        "@typescript-eslint/visitor-keys": "4.33.0",
+        "debug": "^4.3.1",
+        "globby": "^11.0.3",
+        "is-glob": "^4.0.1",
+        "semver": "^7.3.5",
+        "tsutils": "^3.21.0"
+      },
+      "engines": {
+        "node": "^10.12.0 || >=12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-scripts/node_modules/@typescript-eslint/typescript-estree/node_modules/semver": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
+      "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/react-scripts/node_modules/@typescript-eslint/visitor-keys": {
+      "version": "4.33.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-4.33.0.tgz",
+      "integrity": "sha512-uqi/2aSz9g2ftcHWf8uLPJA70rUv6yuMW5Bohw+bwcuzaxQIHaKFZCKGoGXIrc9vkTJ3+0txM73K0Hq3d5wgIg==",
+      "dependencies": {
+        "@typescript-eslint/types": "4.33.0",
+        "eslint-visitor-keys": "^2.0.0"
+      },
+      "engines": {
+        "node": "^8.10.0 || ^10.13.0 || >=11.10.1"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/react-scripts/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/react-scripts/node_modules/camelcase": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.2.1.tgz",
+      "integrity": "sha512-tVI4q5jjFV5CavAU8DXfza/TJcZutVKo/5Foskmsqcm0MsL91moHvwiGNnqaa2o6PF/7yT5ikDRcVcl8Rj6LCA==",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/react-scripts/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/react-scripts/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/react-scripts/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+    },
+    "node_modules/react-scripts/node_modules/eslint-config-react-app": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-react-app/-/eslint-config-react-app-6.0.0.tgz",
+      "integrity": "sha512-bpoAAC+YRfzq0dsTk+6v9aHm/uqnDwayNAXleMypGl6CpxI9oXXscVHo4fk3eJPIn+rsbtNetB4r/ZIidFIE8A==",
+      "dependencies": {
+        "confusing-browser-globals": "^1.0.10"
+      },
+      "engines": {
+        "node": "^10.12.0 || >=12.0.0"
+      },
+      "peerDependencies": {
+        "@typescript-eslint/eslint-plugin": "^4.0.0",
+        "@typescript-eslint/parser": "^4.0.0",
+        "babel-eslint": "^10.0.0",
+        "eslint": "^7.5.0",
+        "eslint-plugin-flowtype": "^5.2.0",
+        "eslint-plugin-import": "^2.22.0",
+        "eslint-plugin-jest": "^24.0.0",
+        "eslint-plugin-jsx-a11y": "^6.3.1",
+        "eslint-plugin-react": "^7.20.3",
+        "eslint-plugin-react-hooks": "^4.0.8",
+        "eslint-plugin-testing-library": "^3.9.0"
+      },
+      "peerDependenciesMeta": {
+        "eslint-plugin-jest": {
+          "optional": true
+        },
+        "eslint-plugin-testing-library": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-scripts/node_modules/eslint-visitor-keys": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz",
+      "integrity": "sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/react-scripts/node_modules/jest-resolve": {
+      "version": "26.6.0",
+      "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-26.6.0.tgz",
+      "integrity": "sha512-tRAz2bwraHufNp+CCmAD8ciyCpXCs1NQxB5EJAmtCFy6BN81loFEGWKzYu26Y62lAJJe4X4jg36Kf+NsQyiStQ==",
+      "dependencies": {
+        "@jest/types": "^26.6.0",
+        "chalk": "^4.0.0",
+        "graceful-fs": "^4.2.4",
+        "jest-pnp-resolver": "^1.2.2",
+        "jest-util": "^26.6.0",
+        "read-pkg-up": "^7.0.1",
+        "resolve": "^1.17.0",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 10.14.2"
+      }
+    },
+    "node_modules/react-scripts/node_modules/prompts": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.0.tgz",
+      "integrity": "sha512-awZAKrk3vN6CroQukBL+R9051a4R3zCZBlJm/HBfrSZ8iTpYix3VX1vU4mveiLpiwmOJT4wokTF9m6HUk4KqWQ==",
+      "dependencies": {
+        "kleur": "^3.0.3",
+        "sisteransi": "^1.0.5"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/react-scripts/node_modules/resolve": {
@@ -26375,7 +26514,8 @@
     "@types/history": {
       "version": "4.7.9",
       "resolved": "https://registry.npmjs.org/@types/history/-/history-4.7.9.tgz",
-      "integrity": "sha512-MUc6zSmU3tEVnkQ78q0peeEjKWPUADMlC/t++2bI8WnAG2tvYRPIgHG8lWkXwqc8MsUF6Z2MOf+Mh5sazOmhiQ=="
+      "integrity": "sha512-MUc6zSmU3tEVnkQ78q0peeEjKWPUADMlC/t++2bI8WnAG2tvYRPIgHG8lWkXwqc8MsUF6Z2MOf+Mh5sazOmhiQ==",
+      "dev": true
     },
     "@types/hoist-non-react-statics": {
       "version": "3.3.1",
@@ -26522,6 +26662,7 @@
       "version": "5.1.17",
       "resolved": "https://registry.npmjs.org/@types/react-router/-/react-router-5.1.17.tgz",
       "integrity": "sha512-RNSXOyb3VyRs/EOGmjBhhGKTbnN6fHWvy5FNLzWfOWOGjgVUKqJZXfpKzLmgoU8h6Hj8mpALj/mbXQASOb92wQ==",
+      "dev": true,
       "requires": {
         "@types/history": "*",
         "@types/react": "*"
@@ -26531,6 +26672,7 @@
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/@types/react-router-dom/-/react-router-dom-5.3.2.tgz",
       "integrity": "sha512-ELEYRUie2czuJzaZ5+ziIp9Hhw+juEw8b7C11YNA4QdLCVbQ3qLi2l4aq8XnlqM7V31LZX8dxUuFUCrzHm6sqQ==",
+      "dev": true,
       "requires": {
         "@types/history": "*",
         "@types/react": "*",
@@ -30078,14 +30220,6 @@
         }
       }
     },
-    "eslint-config-react-app": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-config-react-app/-/eslint-config-react-app-6.0.0.tgz",
-      "integrity": "sha512-bpoAAC+YRfzq0dsTk+6v9aHm/uqnDwayNAXleMypGl6CpxI9oXXscVHo4fk3eJPIn+rsbtNetB4r/ZIidFIE8A==",
-      "requires": {
-        "confusing-browser-globals": "^1.0.10"
-      }
-    },
     "eslint-import-resolver-node": {
       "version": "0.3.6",
       "resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.6.tgz",
@@ -33194,66 +33328,6 @@
       "version": "26.0.0",
       "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-26.0.0.tgz",
       "integrity": "sha512-Gv3ZIs/nA48/Zvjrl34bf+oD76JHiGDUxNOVgUjh3j890sblXryjY4rss71fPtD/njchl6PSE2hIhvyWa1eT0A=="
-    },
-    "jest-resolve": {
-      "version": "26.6.0",
-      "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-26.6.0.tgz",
-      "integrity": "sha512-tRAz2bwraHufNp+CCmAD8ciyCpXCs1NQxB5EJAmtCFy6BN81loFEGWKzYu26Y62lAJJe4X4jg36Kf+NsQyiStQ==",
-      "requires": {
-        "@jest/types": "^26.6.0",
-        "chalk": "^4.0.0",
-        "graceful-fs": "^4.2.4",
-        "jest-pnp-resolver": "^1.2.2",
-        "jest-util": "^26.6.0",
-        "read-pkg-up": "^7.0.1",
-        "resolve": "^1.17.0",
-        "slash": "^3.0.0"
-      },
-      "dependencies": {
-        "ansi-styles": {
-          "version": "4.3.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-          "requires": {
-            "color-convert": "^2.0.1"
-          }
-        },
-        "chalk": {
-          "version": "4.1.2",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-          "requires": {
-            "ansi-styles": "^4.1.0",
-            "supports-color": "^7.1.0"
-          }
-        },
-        "color-convert": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-          "requires": {
-            "color-name": "~1.1.4"
-          }
-        },
-        "color-name": {
-          "version": "1.1.4",
-          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
-        },
-        "has-flag": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
-        },
-        "supports-color": {
-          "version": "7.2.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-          "requires": {
-            "has-flag": "^4.0.0"
-          }
-        }
-      }
     },
     "jest-resolve-dependencies": {
       "version": "26.6.3",
@@ -38820,6 +38894,125 @@
             "@typescript-eslint/types": "4.33.0",
             "@typescript-eslint/typescript-estree": "4.33.0",
             "debug": "^4.3.1"
+          }
+        },
+        "@typescript-eslint/scope-manager": {
+          "version": "4.33.0",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-4.33.0.tgz",
+          "integrity": "sha512-5IfJHpgTsTZuONKbODctL4kKuQje/bzBRkwHE8UOZ4f89Zeddg+EGZs8PD8NcN4LdM3ygHWYB3ukPAYjvl/qbQ==",
+          "requires": {
+            "@typescript-eslint/types": "4.33.0",
+            "@typescript-eslint/visitor-keys": "4.33.0"
+          }
+        },
+        "@typescript-eslint/types": {
+          "version": "4.33.0",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-4.33.0.tgz",
+          "integrity": "sha512-zKp7CjQzLQImXEpLt2BUw1tvOMPfNoTAfb8l51evhYbOEEzdWyQNmHWWGPR6hwKJDAi+1VXSBmnhL9kyVTTOuQ=="
+        },
+        "@typescript-eslint/typescript-estree": {
+          "version": "4.33.0",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-4.33.0.tgz",
+          "integrity": "sha512-rkWRY1MPFzjwnEVHsxGemDzqqddw2QbTJlICPD9p9I9LfsO8fdmfQPOX3uKfUaGRDFJbfrtm/sXhVXN4E+bzCA==",
+          "requires": {
+            "@typescript-eslint/types": "4.33.0",
+            "@typescript-eslint/visitor-keys": "4.33.0",
+            "debug": "^4.3.1",
+            "globby": "^11.0.3",
+            "is-glob": "^4.0.1",
+            "semver": "^7.3.5",
+            "tsutils": "^3.21.0"
+          },
+          "dependencies": {
+            "semver": {
+              "version": "7.3.5",
+              "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
+              "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+              "requires": {
+                "lru-cache": "^6.0.0"
+              }
+            }
+          }
+        },
+        "@typescript-eslint/visitor-keys": {
+          "version": "4.33.0",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-4.33.0.tgz",
+          "integrity": "sha512-uqi/2aSz9g2ftcHWf8uLPJA70rUv6yuMW5Bohw+bwcuzaxQIHaKFZCKGoGXIrc9vkTJ3+0txM73K0Hq3d5wgIg==",
+          "requires": {
+            "@typescript-eslint/types": "4.33.0",
+            "eslint-visitor-keys": "^2.0.0"
+          }
+        },
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "camelcase": {
+          "version": "6.2.1",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.2.1.tgz",
+          "integrity": "sha512-tVI4q5jjFV5CavAU8DXfza/TJcZutVKo/5Foskmsqcm0MsL91moHvwiGNnqaa2o6PF/7yT5ikDRcVcl8Rj6LCA=="
+        },
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+        },
+        "eslint-config-react-app": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/eslint-config-react-app/-/eslint-config-react-app-6.0.0.tgz",
+          "integrity": "sha512-bpoAAC+YRfzq0dsTk+6v9aHm/uqnDwayNAXleMypGl6CpxI9oXXscVHo4fk3eJPIn+rsbtNetB4r/ZIidFIE8A==",
+          "requires": {
+            "confusing-browser-globals": "^1.0.10"
+          }
+        },
+        "eslint-visitor-keys": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz",
+          "integrity": "sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw=="
+        },
+        "jest-resolve": {
+          "version": "26.6.0",
+          "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-26.6.0.tgz",
+          "integrity": "sha512-tRAz2bwraHufNp+CCmAD8ciyCpXCs1NQxB5EJAmtCFy6BN81loFEGWKzYu26Y62lAJJe4X4jg36Kf+NsQyiStQ==",
+          "requires": {
+            "@jest/types": "^26.6.0",
+            "chalk": "^4.0.0",
+            "graceful-fs": "^4.2.4",
+            "jest-pnp-resolver": "^1.2.2",
+            "jest-util": "^26.6.0",
+            "read-pkg-up": "^7.0.1",
+            "resolve": "^1.17.0",
+            "slash": "^3.0.0"
+          }
+        },
+        "prompts": {
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.0.tgz",
+          "integrity": "sha512-awZAKrk3vN6CroQukBL+R9051a4R3zCZBlJm/HBfrSZ8iTpYix3VX1vU4mveiLpiwmOJT4wokTF9m6HUk4KqWQ==",
+          "requires": {
+            "kleur": "^3.0.3",
+            "sisteransi": "^1.0.5"
           }
         },
         "resolve": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,7 +7,7 @@
     "@emotion/styled": "^11.6.0",
     "@material-ui/core": "^4.12.3",
     "@mui/core": "^5.0.0-alpha.54",
-    "@mui/icons-material": "^5.2.4",
+    "@mui/icons-material": "^5.2.5",
     "@mui/material": "^5.2.4",
     "@mui/styles": "^5.2.3",
     "@testing-library/jest-dom": "^5.16.1",

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -5,8 +5,7 @@ import { ReactQueryDevtools } from 'react-query/devtools';
 import { BrowserRouter, Routes, Route } from 'react-router-dom';
 
 import PATHS from 'constants/routes';
-import { Profile, MyCourses, CoursesList, Help, Employees, Requests, Skills } from 'pages';
-
+import { Profile, MyCourses, CoursesList, Help, Employees, Requests, Skills, SignIn } from 'pages';
 import { queryClient } from 'api/base';
 
 import theme from './themeSettings';
@@ -23,6 +22,7 @@ const App: React.FC = () => (
           <Route path={PATHS.employees} element={<Employees />} />
           <Route path={PATHS.requests} element={<Requests />} />
           <Route path={PATHS.skills} element={<Skills />} />
+          <Route path={PATHS.signIn} element={<SignIn />} />
         </Routes>
       </BrowserRouter>
     </ThemeProvider>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -5,7 +5,7 @@ import { ReactQueryDevtools } from 'react-query/devtools';
 import { BrowserRouter, Routes, Route } from 'react-router-dom';
 
 import PATHS from 'constants/routes';
-import { Profile, MyCourses, CoursesList, Help, SignIn } from 'pages';
+import { Profile, MyCourses, CoursesList, Help, Employees, Requests, Skills } from 'pages';
 
 import { queryClient } from 'api/base';
 
@@ -20,7 +20,9 @@ const App: React.FC = () => (
           <Route path={PATHS.myCourses} element={<MyCourses />} />
           <Route path={PATHS.coursesList} element={<CoursesList />} />
           <Route path={PATHS.help} element={<Help />} />
-          <Route path={PATHS.signIn} element={<SignIn />} />
+          <Route path={PATHS.employees} element={<Employees />} />
+          <Route path={PATHS.requests} element={<Requests />} />
+          <Route path={PATHS.skills} element={<Skills />} />
         </Routes>
       </BrowserRouter>
     </ThemeProvider>

--- a/frontend/src/components/Button/index.ts
+++ b/frontend/src/components/Button/index.ts
@@ -1,0 +1,1 @@
+export { default } from './Button';

--- a/frontend/src/components/Button/index.tsx
+++ b/frontend/src/components/Button/index.tsx
@@ -1,2 +1,0 @@
-import Button from './Button';
-export default Button;

--- a/frontend/src/components/TextField/index.ts
+++ b/frontend/src/components/TextField/index.ts
@@ -1,0 +1,1 @@
+export { default } from './TextField';

--- a/frontend/src/components/TextField/index.tsx
+++ b/frontend/src/components/TextField/index.tsx
@@ -1,0 +1,1 @@
+export { default } from './TextField';

--- a/frontend/src/components/TextField/index.tsx
+++ b/frontend/src/components/TextField/index.tsx
@@ -1,1 +1,0 @@
-export { default } from './TextField';

--- a/frontend/src/components/TextField/index.tsx
+++ b/frontend/src/components/TextField/index.tsx
@@ -1,2 +1,0 @@
-import TextField from './TextField';
-export default TextField;

--- a/frontend/src/components/layout/Menu/Menu.tsx
+++ b/frontend/src/components/layout/Menu/Menu.tsx
@@ -1,112 +1,20 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
-import {
-  AccountCircleOutlined,
-  ArticleOutlined,
-  FolderSpecialOutlined,
-  AddToQueueOutlined,
-  EmojiPeopleOutlined,
-  AssessmentOutlined,
-  QuizOutlined,
-} from '@mui/icons-material';
 import { ListItemIcon, ListItemText, ListItemButton } from '@mui/material';
 
-import PATHS from 'constants/routes';
-import { MenuTabs } from 'components/Layout/styled';
+import { MenuTabs } from './styled';
 
-const EMPLOYEE_MENU = [
-  {
-    path: PATHS.profile,
-    title: 'Profile',
-    icon: <AccountCircleOutlined fontSize="large" />,
-  },
-  {
-    path: PATHS.coursesList,
-    title: 'Courses List',
-    icon: <ArticleOutlined fontSize="large" />,
-  },
-  {
-    path: PATHS.myCourses,
-    title: 'My Courses',
-    icon: <AddToQueueOutlined fontSize="large" />,
-  },
-  {
-    path: PATHS.help,
-    title: 'Help',
-    icon: <QuizOutlined fontSize="large" />,
-  },
-];
+import { menuItems } from './MenuContainer';
 
-const MANAGER_MENU = [
-  {
-    path: PATHS.profile,
-    title: 'Profile',
-    icon: <AccountCircleOutlined fontSize="large" />,
-  },
-  {
-    path: PATHS.coursesList,
-    title: 'Courses List',
-    icon: <ArticleOutlined fontSize="large" />,
-  },
-  {
-    path: PATHS.myCourses,
-    title: 'My Courses',
-    icon: <FolderSpecialOutlined fontSize="large" />,
-  },
-  {
-    path: PATHS.requests,
-    title: 'Pending Requests',
-    icon: <AddToQueueOutlined fontSize="large" />,
-  },
-  {
-    path: PATHS.employees,
-    title: 'Employees',
-    icon: <EmojiPeopleOutlined fontSize="large" />,
-  },
-  {
-    path: PATHS.help,
-    title: 'Help',
-    icon: <QuizOutlined fontSize="large" />,
-  },
-];
-
-const ADMIN_MENU = [
-  {
-    path: PATHS.coursesList,
-    title: 'Courses List',
-    icon: <ArticleOutlined fontSize="large" />,
-  },
-  {
-    path: PATHS.skills,
-    title: 'Skills',
-    icon: <AssessmentOutlined fontSize="large" />,
-  },
-  {
-    path: PATHS.help,
-    title: 'Help',
-    icon: <QuizOutlined fontSize="large" />,
-  },
-];
-
-const ROLES_MENU = {
-  employee: EMPLOYEE_MENU,
-  manager: MANAGER_MENU,
-  admin: ADMIN_MENU,
-};
-
-const Menu: React.FC = () => {
-  const menuItems = ROLES_MENU['employee'];
-
-  return (
-    <MenuTabs>
-      {menuItems.map((item, key) => (
-        <ListItemButton key={key} component={Link} to={item.path}>
-          <ListItemIcon>{item.icon}</ListItemIcon>
-          <ListItemText primary={item.title} primaryTypographyProps={{ variant: 'h6' }} />
-        </ListItemButton>
-      ))}
-    </MenuTabs>
-  );
-};
+const Menu: React.FC = () => (
+  <MenuTabs>
+    {menuItems.map((item, key) => (
+      <ListItemButton key={key} component={Link} to={item.path}>
+        <ListItemIcon>{item.icon}</ListItemIcon>
+        <ListItemText primary={item.title} primaryTypographyProps={{ variant: 'h6' }} />
+      </ListItemButton>
+    ))}
+  </MenuTabs>
+);
 
 export default Menu;

--- a/frontend/src/components/layout/Menu/Menu.tsx
+++ b/frontend/src/components/layout/Menu/Menu.tsx
@@ -1,40 +1,112 @@
 import React from 'react';
-import { NavLink } from 'react-router-dom';
-import AccountCircleIcon from '@mui/icons-material/AccountCircle';
-import ArticleIcon from '@mui/icons-material/Article';
-import FolderSpecialIcon from '@mui/icons-material/FolderSpecial';
-import HelpIcon from '@mui/icons-material/Help';
+import { Link } from 'react-router-dom';
+import {
+  AccountCircleOutlined,
+  ArticleOutlined,
+  FolderSpecialOutlined,
+  AddToQueueOutlined,
+  EmojiPeopleOutlined,
+  AssessmentOutlined,
+  QuizOutlined,
+} from '@mui/icons-material';
+import { ListItemIcon, ListItemText, ListItemButton } from '@mui/material';
 
 import PATHS from 'constants/routes';
-import { MenuTabs, MenuTab, MenuTabName } from 'components/Layout/styled';
+import { MenuTabs } from 'components/Layout/styled';
 
-const Menu: React.FC = () => (
-  <MenuTabs>
-    <NavLink to={PATHS.profile}>
-      <MenuTab>
-        <AccountCircleIcon fontSize="large" color="inherit" />
-        <MenuTabName>Profile</MenuTabName>
-      </MenuTab>
-    </NavLink>
-    <NavLink to={PATHS.coursesList}>
-      <MenuTab>
-        <ArticleIcon fontSize="large" color="inherit" />
-        <MenuTabName>Possible courses</MenuTabName>
-      </MenuTab>
-    </NavLink>
-    <NavLink to={PATHS.myCourses}>
-      <MenuTab>
-        <FolderSpecialIcon fontSize="large" color="inherit" />
-        <MenuTabName>My courses</MenuTabName>
-      </MenuTab>
-    </NavLink>
-    <NavLink to={PATHS.help}>
-      <MenuTab>
-        <HelpIcon fontSize="large" color="inherit" />
-        <MenuTabName>Help</MenuTabName>
-      </MenuTab>
-    </NavLink>
-  </MenuTabs>
-);
+const EMPLOYEE_MENU = [
+  {
+    path: PATHS.profile,
+    title: 'Profile',
+    icon: <AccountCircleOutlined fontSize="large" />,
+  },
+  {
+    path: PATHS.coursesList,
+    title: 'Courses List',
+    icon: <ArticleOutlined fontSize="large" />,
+  },
+  {
+    path: PATHS.myCourses,
+    title: 'My Courses',
+    icon: <AddToQueueOutlined fontSize="large" />,
+  },
+  {
+    path: PATHS.help,
+    title: 'Help',
+    icon: <QuizOutlined fontSize="large" />,
+  },
+];
+
+const MANAGER_MENU = [
+  {
+    path: PATHS.profile,
+    title: 'Profile',
+    icon: <AccountCircleOutlined fontSize="large" />,
+  },
+  {
+    path: PATHS.coursesList,
+    title: 'Courses List',
+    icon: <ArticleOutlined fontSize="large" />,
+  },
+  {
+    path: PATHS.myCourses,
+    title: 'My Courses',
+    icon: <FolderSpecialOutlined fontSize="large" />,
+  },
+  {
+    path: PATHS.requests,
+    title: 'Pending Requests',
+    icon: <AddToQueueOutlined fontSize="large" />,
+  },
+  {
+    path: PATHS.employees,
+    title: 'Employees',
+    icon: <EmojiPeopleOutlined fontSize="large" />,
+  },
+  {
+    path: PATHS.help,
+    title: 'Help',
+    icon: <QuizOutlined fontSize="large" />,
+  },
+];
+
+const ADMIN_MENU = [
+  {
+    path: PATHS.coursesList,
+    title: 'Courses List',
+    icon: <ArticleOutlined fontSize="large" />,
+  },
+  {
+    path: PATHS.skills,
+    title: 'Skills',
+    icon: <AssessmentOutlined fontSize="large" />,
+  },
+  {
+    path: PATHS.help,
+    title: 'Help',
+    icon: <QuizOutlined fontSize="large" />,
+  },
+];
+
+const ROLES_MENU = {
+  employee: EMPLOYEE_MENU,
+  manager: MANAGER_MENU,
+  admin: ADMIN_MENU,
+};
+
+const Menu: React.FC = () => {
+  const menuItems = ROLES_MENU['employee'];
+
+  return (
+    <MenuTabs>
+      {menuItems.map((item, key) => (
+        <ListItemButton key={key} component={Link} to={item.path}>
+          <ListItemIcon>{item.icon}</ListItemIcon>
+          <ListItemText primary={item.title} primaryTypographyProps={{ variant: 'h6' }} />
+        </ListItemButton>
+      ))}
+    </MenuTabs>
+  );
+};
 
 export default Menu;

--- a/frontend/src/components/layout/Menu/Menu.tsx
+++ b/frontend/src/components/layout/Menu/Menu.tsx
@@ -4,11 +4,20 @@ import { ListItemIcon, ListItemText, ListItemButton } from '@mui/material';
 
 import { MenuTabs } from './styled';
 
-import { menuItems } from './MenuContainer';
+interface MenuItemProps {
+  path: string;
+  title: string;
+  icon: React.ReactElement;
+}
 
-const Menu: React.FC = () => (
+interface MenuProps {
+  menuList: MenuItemProps[];
+  children?: React.ReactNode;
+}
+
+const Menu: React.FC<MenuProps> = ({ menuList }) => (
   <MenuTabs>
-    {menuItems.map((item, key) => (
+    {menuList.map((item, key) => (
       <ListItemButton key={key} component={Link} to={item.path}>
         <ListItemIcon>{item.icon}</ListItemIcon>
         <ListItemText primary={item.title} primaryTypographyProps={{ variant: 'h6' }} />

--- a/frontend/src/components/layout/Menu/MenuContainer.tsx
+++ b/frontend/src/components/layout/Menu/MenuContainer.tsx
@@ -1,0 +1,100 @@
+import React from 'react';
+import {
+  AccountCircleOutlined,
+  ArticleOutlined,
+  FolderSpecialOutlined,
+  AddToQueueOutlined,
+  EmojiPeopleOutlined,
+  AssessmentOutlined,
+  QuizOutlined,
+} from '@mui/icons-material';
+
+import PATHS from 'constants/routes';
+
+import Menu from './Menu';
+
+const EMPLOYEE_MENU = [
+  {
+    path: PATHS.profile,
+    title: 'Profile',
+    icon: <AccountCircleOutlined fontSize="large" />,
+  },
+  {
+    path: PATHS.coursesList,
+    title: 'Courses List',
+    icon: <ArticleOutlined fontSize="large" />,
+  },
+  {
+    path: PATHS.myCourses,
+    title: 'My Courses',
+    icon: <AddToQueueOutlined fontSize="large" />,
+  },
+  {
+    path: PATHS.help,
+    title: 'Help',
+    icon: <QuizOutlined fontSize="large" />,
+  },
+];
+
+const MANAGER_MENU = [
+  {
+    path: PATHS.profile,
+    title: 'Profile',
+    icon: <AccountCircleOutlined fontSize="large" />,
+  },
+  {
+    path: PATHS.coursesList,
+    title: 'Courses List',
+    icon: <ArticleOutlined fontSize="large" />,
+  },
+  {
+    path: PATHS.myCourses,
+    title: 'My Courses',
+    icon: <FolderSpecialOutlined fontSize="large" />,
+  },
+  {
+    path: PATHS.requests,
+    title: 'Pending Requests',
+    icon: <AddToQueueOutlined fontSize="large" />,
+  },
+  {
+    path: PATHS.employees,
+    title: 'Employees',
+    icon: <EmojiPeopleOutlined fontSize="large" />,
+  },
+  {
+    path: PATHS.help,
+    title: 'Help',
+    icon: <QuizOutlined fontSize="large" />,
+  },
+];
+
+const ADMIN_MENU = [
+  {
+    path: PATHS.coursesList,
+    title: 'Courses List',
+    icon: <ArticleOutlined fontSize="large" />,
+  },
+  {
+    path: PATHS.skills,
+    title: 'Skills',
+    icon: <AssessmentOutlined fontSize="large" />,
+  },
+  {
+    path: PATHS.help,
+    title: 'Help',
+    icon: <QuizOutlined fontSize="large" />,
+  },
+];
+
+const ROLES_MENU = {
+  employee: EMPLOYEE_MENU,
+  manager: MANAGER_MENU,
+  admin: ADMIN_MENU,
+};
+
+export const menuItems = ROLES_MENU['employee'];
+
+const MenuContainer: React.FC = () => <Menu />;
+
+export default MenuContainer;

--- a/frontend/src/components/layout/Menu/MenuContainer.tsx
+++ b/frontend/src/components/layout/Menu/MenuContainer.tsx
@@ -1,100 +1,13 @@
 import React from 'react';
-import {
-  AccountCircleOutlined,
-  ArticleOutlined,
-  FolderSpecialOutlined,
-  AddToQueueOutlined,
-  EmojiPeopleOutlined,
-  AssessmentOutlined,
-  QuizOutlined,
-} from '@mui/icons-material';
 
-import PATHS from 'constants/routes';
+import { ROLES_MENU } from 'constants/menuRoles';
 
 import Menu from './Menu';
 
-const EMPLOYEE_MENU = [
-  {
-    path: PATHS.profile,
-    title: 'Profile',
-    icon: <AccountCircleOutlined fontSize="large" />,
-  },
-  {
-    path: PATHS.coursesList,
-    title: 'Courses List',
-    icon: <ArticleOutlined fontSize="large" />,
-  },
-  {
-    path: PATHS.myCourses,
-    title: 'My Courses',
-    icon: <AddToQueueOutlined fontSize="large" />,
-  },
-  {
-    path: PATHS.help,
-    title: 'Help',
-    icon: <QuizOutlined fontSize="large" />,
-  },
-];
+const MenuContainer: React.FC = () => {
+  const menuItems = ROLES_MENU['employee'];
 
-const MANAGER_MENU = [
-  {
-    path: PATHS.profile,
-    title: 'Profile',
-    icon: <AccountCircleOutlined fontSize="large" />,
-  },
-  {
-    path: PATHS.coursesList,
-    title: 'Courses List',
-    icon: <ArticleOutlined fontSize="large" />,
-  },
-  {
-    path: PATHS.myCourses,
-    title: 'My Courses',
-    icon: <FolderSpecialOutlined fontSize="large" />,
-  },
-  {
-    path: PATHS.requests,
-    title: 'Pending Requests',
-    icon: <AddToQueueOutlined fontSize="large" />,
-  },
-  {
-    path: PATHS.employees,
-    title: 'Employees',
-    icon: <EmojiPeopleOutlined fontSize="large" />,
-  },
-  {
-    path: PATHS.help,
-    title: 'Help',
-    icon: <QuizOutlined fontSize="large" />,
-  },
-];
-
-const ADMIN_MENU = [
-  {
-    path: PATHS.coursesList,
-    title: 'Courses List',
-    icon: <ArticleOutlined fontSize="large" />,
-  },
-  {
-    path: PATHS.skills,
-    title: 'Skills',
-    icon: <AssessmentOutlined fontSize="large" />,
-  },
-  {
-    path: PATHS.help,
-    title: 'Help',
-    icon: <QuizOutlined fontSize="large" />,
-  },
-];
-
-const ROLES_MENU = {
-  employee: EMPLOYEE_MENU,
-  manager: MANAGER_MENU,
-  admin: ADMIN_MENU,
+  return <Menu menuList={menuItems} />;
 };
-
-export const menuItems = ROLES_MENU['employee'];
-
-const MenuContainer: React.FC = () => <Menu />;
 
 export default MenuContainer;

--- a/frontend/src/components/layout/Menu/index.ts
+++ b/frontend/src/components/layout/Menu/index.ts
@@ -1,1 +1,1 @@
-export { default } from './Menu';
+export { default } from './MenuContainer';

--- a/frontend/src/components/layout/Menu/styled.ts
+++ b/frontend/src/components/layout/Menu/styled.ts
@@ -1,0 +1,14 @@
+import styled from 'styled-components';
+
+import { HEADER_HEIGHT } from '../styled';
+
+export const MenuTabs = styled('div')({
+  width: '300px',
+  height: `calc(100vh - ${HEADER_HEIGHT})`,
+  backgroundColor: 'white',
+  borderRight: '2px solid #f0f2f7',
+  fontSize: '24px',
+  fontFamily: '"Lato", sans-serif',
+  margin: '0px',
+  paddingTop: '20px',
+});

--- a/frontend/src/components/layout/styled.ts
+++ b/frontend/src/components/layout/styled.ts
@@ -2,7 +2,7 @@ import styled from 'styled-components';
 import LogoutIcon from '@mui/icons-material/Logout';
 import Grid from '@mui/material/Grid';
 
-const HEADER_HEIGHT = '70px';
+export const HEADER_HEIGHT = '70px';
 
 export const LayoutHeader = styled(Grid)({
   width: 'calc(100vw-10px)',
@@ -10,6 +10,7 @@ export const LayoutHeader = styled(Grid)({
   borderBottom: '2px solid #f0f2f7',
   fontFamily: '"Lato", sans-serif',
 });
+
 export const HeaderDivider = styled('div')({
   display: 'inline-block',
   width: '1px',
@@ -18,6 +19,7 @@ export const HeaderDivider = styled('div')({
   marginTop: '23px',
   marginBottom: '2px',
 });
+
 export const BrandLogo = styled('div')({
   display: 'block',
   height: '68px',
@@ -26,6 +28,7 @@ export const BrandLogo = styled('div')({
   borderRight: '2px solid #f0f2f7',
   color: '#d83938',
 });
+
 export const HeaderContent = styled('div')({
   display: 'grid',
   gridTemplateColumns: '1fr 130px 1px 340px 1px 100px',
@@ -33,9 +36,11 @@ export const HeaderContent = styled('div')({
   maxWidth: '1200px',
   textAlign: 'right',
 });
+
 export const SpaceHolder = styled('div')({
   display: 'inline-block',
 });
+
 export const Counter = styled('div')({
   display: 'inline-block',
   width: '70px',
@@ -48,9 +53,11 @@ export const Counter = styled('div')({
   fontSize: '18px',
   fontFamily: '"Lato", sans-serif',
 });
+
 export const MyCoursesCounterContent = styled('div')({
   display: 'flex',
 });
+
 export const MyCoursesCounterNumber = styled('span')({
   display: 'inline-block',
   height: '18px',
@@ -58,6 +65,7 @@ export const MyCoursesCounterNumber = styled('span')({
   padding: '2px 8px 8px 5px',
   textAlign: 'center',
 });
+
 export const LogOut = styled(LogoutIcon)({
   display: 'inline-block',
   width: '50px',
@@ -68,31 +76,4 @@ export const LogOut = styled(LogoutIcon)({
   '&:hover': {
     cursor: 'pointer',
   },
-});
-export const MenuTabs = styled('div')({
-  width: '100%',
-  height: `calc(100vh - ${HEADER_HEIGHT})`,
-  backgroundColor: 'white',
-  borderRight: '2px solid #f0f2f7',
-  fontSize: '24px',
-  fontFamily: '"Lato", sans-serif',
-  margin: '0px',
-  paddingTop: '20px',
-});
-export const MenuTab = styled('div')({
-  display: 'flex',
-  height: '60px',
-  padding: '14px 20px 18px 20px',
-  borderLeft: '3px solid white',
-  color: 'black',
-  '&:hover': {
-    cursor: 'pointer',
-    color: '#d83938',
-    borderLeft: '3px solid #d83938',
-  },
-});
-export const MenuTabName = styled('span')({
-  display: 'inline-block',
-  height: '24px',
-  padding: '4px 0px 0px 8px',
 });

--- a/frontend/src/constants/menuRoles.tsx
+++ b/frontend/src/constants/menuRoles.tsx
@@ -1,0 +1,91 @@
+import React from 'react';
+import PATHS from './routes';
+import {
+  AccountCircleOutlined,
+  ArticleOutlined,
+  FolderSpecialOutlined,
+  AddToQueueOutlined,
+  EmojiPeopleOutlined,
+  AssessmentOutlined,
+  QuizOutlined,
+} from '@mui/icons-material';
+
+const EMPLOYEE_MENU = [
+  {
+    path: PATHS.profile,
+    title: 'Profile',
+    icon: <AccountCircleOutlined fontSize="large" />,
+  },
+  {
+    path: PATHS.coursesList,
+    title: 'Courses List',
+    icon: <ArticleOutlined fontSize="large" />,
+  },
+  {
+    path: PATHS.myCourses,
+    title: 'My Courses',
+    icon: <AddToQueueOutlined fontSize="large" />,
+  },
+  {
+    path: PATHS.help,
+    title: 'Help',
+    icon: <QuizOutlined fontSize="large" />,
+  },
+];
+
+const MANAGER_MENU = [
+  {
+    path: PATHS.profile,
+    title: 'Profile',
+    icon: <AccountCircleOutlined fontSize="large" />,
+  },
+  {
+    path: PATHS.coursesList,
+    title: 'Courses List',
+    icon: <ArticleOutlined fontSize="large" />,
+  },
+  {
+    path: PATHS.myCourses,
+    title: 'My Courses',
+    icon: <FolderSpecialOutlined fontSize="large" />,
+  },
+  {
+    path: PATHS.requests,
+    title: 'Pending Requests',
+    icon: <AddToQueueOutlined fontSize="large" />,
+  },
+  {
+    path: PATHS.employees,
+    title: 'Employees',
+    icon: <EmojiPeopleOutlined fontSize="large" />,
+  },
+  {
+    path: PATHS.help,
+    title: 'Help',
+    icon: <QuizOutlined fontSize="large" />,
+  },
+];
+
+const ADMIN_MENU = [
+  {
+    path: PATHS.coursesList,
+    title: 'Courses List',
+    icon: <ArticleOutlined fontSize="large" />,
+  },
+  {
+    path: PATHS.skills,
+    title: 'Skills',
+    icon: <AssessmentOutlined fontSize="large" />,
+  },
+  {
+    path: PATHS.help,
+    title: 'Help',
+    icon: <QuizOutlined fontSize="large" />,
+  },
+];
+
+export const ROLES_MENU = {
+  employee: EMPLOYEE_MENU,
+  manager: MANAGER_MENU,
+  admin: ADMIN_MENU,
+};

--- a/frontend/src/constants/menuRoles.tsx
+++ b/frontend/src/constants/menuRoles.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import PATHS from './routes';
 import {
   AccountCircleOutlined,
   ArticleOutlined,
@@ -9,6 +8,8 @@ import {
   AssessmentOutlined,
   QuizOutlined,
 } from '@mui/icons-material';
+
+import PATHS from './routes';
 
 const EMPLOYEE_MENU = [
   {

--- a/frontend/src/constants/routes.ts
+++ b/frontend/src/constants/routes.ts
@@ -5,6 +5,9 @@ const PATHS: {
   myCourses: string;
   help: string;
   signIn: string;
+  requests: string;
+  employees: string;
+  skills: string;
 } = {
   home: '/',
   profile: '/profile',
@@ -12,6 +15,9 @@ const PATHS: {
   myCourses: '/my-courses',
   help: '/help',
   signIn: '/signin',
+  requests: '/pending-requests',
+  employees: '/employees',
+  skills: '/skills',
 };
 
 export default PATHS;

--- a/frontend/src/pages/Employees/Employees.tsx
+++ b/frontend/src/pages/Employees/Employees.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+
+import { AuthorizedLayout } from 'components/Layout';
+
+const Employees: React.FC = () => (
+  <AuthorizedLayout pageName="Employees">
+    <div>Employees should be here</div>
+  </AuthorizedLayout>
+);
+
+export default Employees;

--- a/frontend/src/pages/Employees/index.ts
+++ b/frontend/src/pages/Employees/index.ts
@@ -1,0 +1,1 @@
+export { default } from './Employees';

--- a/frontend/src/pages/Requests/Requests.tsx
+++ b/frontend/src/pages/Requests/Requests.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+
+import { AuthorizedLayout } from 'components/Layout';
+
+const Requests: React.FC = () => (
+  <AuthorizedLayout pageName="Requests">
+    <div>Requests should be here</div>
+  </AuthorizedLayout>
+);
+
+export default Requests;

--- a/frontend/src/pages/Requests/index.ts
+++ b/frontend/src/pages/Requests/index.ts
@@ -1,0 +1,1 @@
+export { default } from './Requests';

--- a/frontend/src/pages/Skills/Skills.tsx
+++ b/frontend/src/pages/Skills/Skills.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+
+import { AuthorizedLayout } from 'components/Layout';
+
+const Skills: React.FC = () => (
+  <AuthorizedLayout pageName="Skills">
+    <div>Skills should be here</div>
+  </AuthorizedLayout>
+);
+
+export default Skills;

--- a/frontend/src/pages/Skills/index.ts
+++ b/frontend/src/pages/Skills/index.ts
@@ -1,0 +1,1 @@
+export { default } from './Skills';

--- a/frontend/src/pages/index.ts
+++ b/frontend/src/pages/index.ts
@@ -3,3 +3,6 @@ export { default as Help } from './Help';
 export { default as MyCourses } from './MyCourses';
 export { default as Profile } from './Profile';
 export { default as SignIn } from './SignIn/SignInContainer';
+export { default as Employees } from './Employees';
+export { default as Requests } from './Requests';
+export { default as Skills } from './Skills';

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -19,7 +19,7 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
     "noEmit": true,
-    "jsx": "react-jsx"
+    "jsx": "react-jsx",
   },
   "include": [
     "src"

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -2,7 +2,11 @@
   "compilerOptions": {
     "baseUrl": "src",
     "target": "es5",
-    "lib": ["dom", "dom.iterable", "esnext"],
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "esnext"
+    ],
     "allowJs": true,
     "skipLibCheck": true,
     "esModuleInterop": true,
@@ -15,7 +19,7 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
     "noEmit": true,
-    "jsx": "react-jsx",
+    "jsx": "react-jsx"
   },
   "include": [
     "src"


### PR DESCRIPTION
**Overview:**

1. Implement Menu according to Role of the client 

    Now we can change the role manually in this way:
   `export const menuItems = ROLES_MENU['employee'];` 
   ('employee', 'manager', and 'admin' roles are available for use)
    Later we will get user's role from the server

2. Add Employees, Requests and Skills pages

3. Change index.ts in components folders for better readability 

4. Add MenuContainer and styled.js inside Menu folder 
