### PR TITLE
Fixed: No Content displayed in center

### DIFF
--- a/frontend/src/components/Layout/Menu/styled.ts
+++ b/frontend/src/components/Layout/Menu/styled.ts
@@ -3,7 +3,7 @@ import styled from 'styled-components';
 import { HEADER_HEIGHT } from '../styled';
 
 export const MenuTabs = styled('div')({
-  width: '300px',
+  width: '100%',
   height: `calc(100vh - ${HEADER_HEIGHT})`,
   backgroundColor: 'white',
   borderRight: '2px solid #f0f2f7',


### PR DESCRIPTION
We had a problem with menu width, so it seemed like pages content was not centered, even though it was. I've set visible menu width to equal real width of its container (grid element).