### PR TITLE
V1-050 feat: implement correct Not Found page displaying for unauthorised users

### DIFF
--- a/frontend/src/pages/NotFound/NotFound.tsx
+++ b/frontend/src/pages/NotFound/NotFound.tsx
@@ -1,19 +1,18 @@
+import { Grid } from '@mui/material';
 import React from 'react';
-
-import { AuthorizedLayout } from 'components/Layout';
 
 import { ErrorText, NotFoundWrapper, StyledText, UnderErrorText } from './styled';
 
 const NotFound: React.FC = () => (
-  <AuthorizedLayout pageName="Not Found">
-    <NotFoundWrapper>
-      <ErrorText>
+  <NotFoundWrapper container>
+    <Grid item>
+      <ErrorText align="center">
         <StyledText>404 </StyledText>
         Error
       </ErrorText>
       <UnderErrorText>Page not found</UnderErrorText>
-    </NotFoundWrapper>
-  </AuthorizedLayout>
+    </Grid>
+  </NotFoundWrapper>
 );
 
 export default NotFound;

--- a/frontend/src/pages/NotFound/NotFoundContainer.tsx
+++ b/frontend/src/pages/NotFound/NotFoundContainer.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+
+import { AuthorizedLayout, DefaultLayout } from 'components/Layout';
+import { getAuthResponseData } from 'utils/helpers/getAuthResponseData';
+
+import NotFound from './NotFound';
+import { DefaultWrapper } from './styled';
+
+const NotFoundContainer: React.FC = () => {
+  const accessToken = getAuthResponseData();
+
+  return accessToken ? (
+    <AuthorizedLayout pageName="Not found">
+      <NotFound />
+    </AuthorizedLayout>
+  ) : (
+    <DefaultLayout pageName="Not found">
+      <DefaultWrapper>
+        <NotFound />
+      </DefaultWrapper>
+    </DefaultLayout>
+  );
+};
+
+export default NotFoundContainer;

--- a/frontend/src/pages/NotFound/index.ts
+++ b/frontend/src/pages/NotFound/index.ts
@@ -1,1 +1,1 @@
-export { default } from './NotFound';
+export { default } from './NotFoundContainer';

--- a/frontend/src/pages/NotFound/styled.ts
+++ b/frontend/src/pages/NotFound/styled.ts
@@ -1,16 +1,17 @@
-import { Typography } from '@mui/material';
+import { Grid, Typography } from '@mui/material';
 import { Box } from '@mui/system';
 import styled from 'styled-components';
 
 import theme from 'themeSettings';
 
-export const NotFoundWrapper = styled(Box)({
+export const NotFoundWrapper = styled(Grid)({
   height: '100%',
-  width: '100%',
-  display: 'flex',
-  flexDirection: 'column',
-  alignItems: 'center',
   justifyContent: 'center',
+  alignItems: 'center',
+});
+
+export const DefaultWrapper = styled(Box)({
+  height: '100vh',
 });
 
 export const ErrorText = styled(Typography)({


### PR DESCRIPTION
Overview:
1. Implement 2 types of displaying the Not Found page : for authorised and unauthorised users
 If the user is not logged in and tries to open a page with an incorrect URL, the top bar and menu are not displayed, only the error is displayed