### PR TITLE
Bugfix/v1-090. Fixed rules of startTest endpoint according to QA issues.

### DIFF
--- a/backend/src/controllers/tests/startTest.ts
+++ b/backend/src/controllers/tests/startTest.ts
@@ -17,7 +17,7 @@ const startTest = async (req: Request, res: Response, next: NextFunction) => {
 
     if (courseStatus !== CourseStatus.started) {
       throw new BadRequestError(
-        `Failed: can not start testing course with status: ${courseStatus}`,
+        `Failed: can not start testing course with status: ${courseStatus}.`,
       );
     }
 
@@ -26,7 +26,7 @@ const startTest = async (req: Request, res: Response, next: NextFunction) => {
     }
 
     await updateCourseStatus(clientCourseId, CourseStatus.testing);
-    res.json('Test started successfully ');
+    res.json('Test has been started successfully.');
   } catch (err) {
     next(err);
   }

--- a/backend/src/utils/validation/checkDuplicates.ts
+++ b/backend/src/utils/validation/checkDuplicates.ts
@@ -1,6 +1,5 @@
 import CourseStatus from 'enums/coursesEnums';
 import { IClientCourse } from 'interfaces/Ientities/IclientCourses';
-import CourseStatus from 'enums/coursesEnums';
 
 const checkCourseDuplicates = (courseArr: IClientCourse[], courseId: string): boolean => {
   const alreadyAppliedCourse = courseArr.find((clientCourse) => {


### PR DESCRIPTION
# Overview
>  
> New rules to start the testing:
> - status: `started`
> - course progress: `100%`