### PR TITLE
Bugfix/V1-073 + V1-096 + API requests for learning course

### DIFF
--- a/frontend/src/api/courses/getCourseInfo.ts
+++ b/frontend/src/api/courses/getCourseInfo.ts
@@ -6,13 +6,13 @@ import { API } from 'constants/routes';
 import { REQUEST_ERRORS } from 'constants/authConstants';
 import { Course } from 'types/course';
 
-const useGetCourseInfo = (_id: string | undefined): UseQueryResult<Course, AxiosError> =>
+const useGetCourseInfo = (courseId: string | undefined): UseQueryResult<Course, AxiosError> =>
   useQuery(
-    ['CourseInfo', _id],
+    ['CourseInfo', courseId],
     async () => {
       const apiClient = apiClientWrapper();
       try {
-        const response = await apiClient.get(`${API.getCourses}/${_id}`);
+        const response = await apiClient.get(`${API.getCourses}/${courseId}`);
         const courseResponse: Array<Course> = response.data;
         return courseResponse;
       } catch (error) {

--- a/frontend/src/api/myCourses/finishClientCourse.ts
+++ b/frontend/src/api/myCourses/finishClientCourse.ts
@@ -1,0 +1,16 @@
+import { useMutation, UseMutationResult } from 'react-query';
+import { AxiosError } from 'axios';
+
+import { apiClientWrapper } from 'api/base';
+import { API } from 'constants/routes';
+import { ClientCourse } from 'types/clientCourse';
+
+const useFinishClientCourse = (courseId?: string): UseMutationResult<ClientCourse, AxiosError> => {
+  return useMutation(async () => {
+    const apiClient = apiClientWrapper();
+    const response = await apiClient.get(`${API.getMyCourses}/${courseId}/finish`);
+    return response.data;
+  });
+};
+
+export default useFinishClientCourse;

--- a/frontend/src/api/myCourses/finishClientCourse.ts
+++ b/frontend/src/api/myCourses/finishClientCourse.ts
@@ -5,7 +5,9 @@ import { apiClientWrapper } from 'api/base';
 import { API } from 'constants/routes';
 import { ClientCourse } from 'types/clientCourse';
 
-const useFinishClientCourse = (courseId?: string): UseMutationResult<ClientCourse, AxiosError> => {
+const useFinishClientCourse = (
+  courseId: string | undefined,
+): UseMutationResult<ClientCourse, AxiosError> => {
   return useMutation(async () => {
     const apiClient = apiClientWrapper();
     const response = await apiClient.get(`${API.getMyCourses}/${courseId}/finish`);

--- a/frontend/src/api/myCourses/getMyCourseInfo.ts
+++ b/frontend/src/api/myCourses/getMyCourseInfo.ts
@@ -6,13 +6,13 @@ import { API } from 'constants/routes';
 import { REQUEST_ERRORS } from 'constants/authConstants';
 import { ClientCourse } from 'types/clientCourse';
 
-const useGetClientCourseInfo = (_id?: string): UseQueryResult<ClientCourse, AxiosError> =>
+const useGetClientCourseInfo = (courseId?: string): UseQueryResult<ClientCourse, AxiosError> =>
   useQuery(
-    ['ClientCourseInfo', _id],
+    ['ClientCourseInfo', courseId],
     async () => {
       const apiClient = apiClientWrapper();
       try {
-        const response = await apiClient.get(`${API.getMyCourses}/${_id}`);
+        const response = await apiClient.get(`${API.getMyCourses}/${courseId}`);
         const courseResponse: Array<ClientCourse> = response.data;
         return courseResponse;
       } catch (error) {

--- a/frontend/src/api/myCourses/index.ts
+++ b/frontend/src/api/myCourses/index.ts
@@ -1,1 +1,2 @@
 export { default as useGetMyCourses } from './getMyCourses';
+export { default as useStartClientCourse } from './startClientCourse';

--- a/frontend/src/api/myCourses/passClientCourse.ts
+++ b/frontend/src/api/myCourses/passClientCourse.ts
@@ -1,0 +1,18 @@
+import { useMutation, UseMutationResult } from 'react-query';
+
+import { apiClientWrapper } from 'api/base';
+import { API } from 'constants/routes';
+import { IPassingTestResponse } from 'types/test';
+
+const usePassClientCourse = (
+  courseId: string | undefined,
+): UseMutationResult<IPassingTestResponse> => {
+  return useMutation(async (stage) => {
+    const apiClient = apiClientWrapper();
+    const url = `${API.getMyCourses}/${courseId}?stage=${stage}`;
+    const response = await apiClient.put(url, stage);
+    return response.data;
+  });
+};
+
+export default usePassClientCourse;

--- a/frontend/src/api/myCourses/startClientCourse.ts
+++ b/frontend/src/api/myCourses/startClientCourse.ts
@@ -1,0 +1,27 @@
+import { useQuery, UseQueryResult } from 'react-query';
+import { AxiosError } from 'axios';
+
+import { apiClientWrapper } from 'api/base';
+import { API } from 'constants/routes';
+import { REQUEST_ERRORS } from 'constants/authConstants';
+import { ClientCourse } from 'types/clientCourse';
+
+const useStartClientCourse = (_id?: string): UseQueryResult<ClientCourse, AxiosError> =>
+  useQuery(
+    ['StartClientCourse', _id],
+    async () => {
+      const apiClient = apiClientWrapper();
+      try {
+        const response = await apiClient.get(`${API.getMyCourses}/${_id}/start`);
+        const courseResponse: Array<ClientCourse> = response.data;
+        return courseResponse;
+      } catch (error) {
+        throw new Error(`${REQUEST_ERRORS.getError}`);
+      }
+    },
+    {
+      refetchOnWindowFocus: false,
+    },
+  );
+
+export default useStartClientCourse;

--- a/frontend/src/api/myCourses/startClientCourse.ts
+++ b/frontend/src/api/myCourses/startClientCourse.ts
@@ -6,13 +6,13 @@ import { API } from 'constants/routes';
 import { REQUEST_ERRORS } from 'constants/authConstants';
 import { ClientCourse } from 'types/clientCourse';
 
-const useStartClientCourse = (_id?: string): UseQueryResult<ClientCourse, AxiosError> =>
+const useStartClientCourse = (courseId?: string): UseQueryResult<ClientCourse, AxiosError> =>
   useQuery(
-    ['StartClientCourse', _id],
+    ['StartClientCourse', courseId],
     async () => {
       const apiClient = apiClientWrapper();
       try {
-        const response = await apiClient.get(`${API.getMyCourses}/${_id}/start`);
+        const response = await apiClient.get(`${API.getMyCourses}/${courseId}/start`);
         const courseResponse: Array<ClientCourse> = response.data;
         return courseResponse;
       } catch (error) {

--- a/frontend/src/api/myCourses/startClientCourse.ts
+++ b/frontend/src/api/myCourses/startClientCourse.ts
@@ -6,8 +6,12 @@ import { API } from 'constants/routes';
 import { REQUEST_ERRORS } from 'constants/authConstants';
 import { ClientCourse } from 'types/clientCourse';
 
-const useStartClientCourse = (courseId?: string): UseQueryResult<ClientCourse, AxiosError> =>
-  useQuery(
+const useStartClientCourse = (params: {
+  courseId?: string | undefined;
+  enabled?: boolean;
+}): UseQueryResult<ClientCourse, AxiosError> => {
+  const { courseId, enabled = true } = params;
+  return useQuery(
     ['StartClientCourse', courseId],
     async () => {
       const apiClient = apiClientWrapper();
@@ -20,8 +24,9 @@ const useStartClientCourse = (courseId?: string): UseQueryResult<ClientCourse, A
       }
     },
     {
-      refetchOnWindowFocus: false,
+      enabled,
     },
   );
+};
 
 export default useStartClientCourse;

--- a/frontend/src/components/Button/Button.tsx
+++ b/frontend/src/components/Button/Button.tsx
@@ -7,6 +7,7 @@ declare module '@mui/material/Button' {
     mediumOutlined: true;
     mediumContained: true;
     large: true;
+    completed: true;
   }
 }
 

--- a/frontend/src/constants/test.ts
+++ b/frontend/src/constants/test.ts
@@ -6,4 +6,5 @@ export const PERCENTAGE = 100;
 export const TEST_STATUS = {
   notPassed: 'not passed',
   successful: 'successful',
+  testing: 'testing',
 };

--- a/frontend/src/pages/CoursesList/CoursesList.tsx
+++ b/frontend/src/pages/CoursesList/CoursesList.tsx
@@ -13,6 +13,7 @@ import { buttonSpinner } from 'animations';
 import { LOADER } from 'constants/loaderTypes';
 import MobileSearch from 'components/Layout/MobileSearch';
 import { PAGES } from 'constants/pages';
+import { COURSE_STATUSES } from 'constants/statuses';
 
 import {
   PageContainer,
@@ -23,6 +24,7 @@ import {
   StartCourseButton,
   MobileLink,
   MobileSearchWrapper,
+  CompletedButton,
 } from './styled';
 
 interface Props {
@@ -82,7 +84,11 @@ const CoursesList: React.FC<CoursesProps> = ({
                           Details
                         </DetailsButton>
                       </Link>
-                      {targetLoading && targetId === course._id ? (
+                      {course.status === COURSE_STATUSES.completed ? (
+                        <CompletedButton variant="completed" disabled>
+                          Completed
+                        </CompletedButton>
+                      ) : targetLoading && targetId === course._id ? (
                         <StartCourseButton variant="mediumOutlined" disabled>
                           <ButtonLoader buttonSpinner={buttonSpinner} />
                         </StartCourseButton>

--- a/frontend/src/pages/CoursesList/styled.ts
+++ b/frontend/src/pages/CoursesList/styled.ts
@@ -43,26 +43,6 @@ export const GridItem = styled(Grid)({
   },
 });
 
-export const CourseButton = styled(Button)({
-  [theme.breakpoints.up('xs')]: {
-    margin: '3px',
-    fontSize: '10px',
-    alignSelf: 'center',
-    height: '40px',
-    width: '120px',
-    lineHeight: '10px',
-  },
-  [theme.breakpoints.up('sm')]: {
-    width: '140px',
-    marginLeft: '5px',
-    height: '40px',
-    fontSize: '10px',
-    alignSelf: 'center',
-    lineHeight: '10px',
-  },
-  marginRight: '20px',
-});
-
 export const CourseActions = styled('div')({
   [theme.breakpoints.down('md')]: {
     display: 'flex',
@@ -137,5 +117,27 @@ export const MobileSearchWrapper = styled('div')({
   height: '30px',
   '@media(min-width: 1110px)': {
     display: 'none',
+  },
+});
+
+export const CompletedButton = styled(Button)({
+  [theme.breakpoints.up('sm')]: {
+    height: '44px',
+    width: '121px',
+    marginRight: '36px !important',
+    fontSize: '14px!important',
+    lineHeight: '19px',
+    padding: '10px 0px !important',
+  },
+  [theme.breakpoints.up('xl')]: {
+    height: '50px',
+    width: '150px',
+    marginRight: '40px !important',
+    fontSize: '18px!important',
+    lineHeight: '22px',
+    padding: '12px 12px!important',
+    justifySelf: 'flex-start',
+    alignSelf: 'center',
+    display: 'flex',
   },
 });

--- a/frontend/src/pages/LearningCourse/FormDialog/FormDialog.tsx
+++ b/frontend/src/pages/LearningCourse/FormDialog/FormDialog.tsx
@@ -5,6 +5,7 @@ import { useParams } from 'react-router';
 import { close } from 'icons';
 import { ConfirmDialog } from 'components/ConfirmDialog';
 import { PATHS } from 'constants/routes';
+import { COURSE_STATUSES } from 'constants/statuses';
 import { useGetCourseTest } from 'api/test';
 import { convertTestTimeout } from 'utils/helpers/convertTestTimeout';
 
@@ -24,11 +25,15 @@ import {
 interface IFormDialog {
   dialogOpen: boolean;
   handleDialogClose: () => void;
+  courseStatus: string;
 }
 
-const FormDialog: React.FC<IFormDialog> = ({ dialogOpen, handleDialogClose }) => {
+const FormDialog: React.FC<IFormDialog> = ({ dialogOpen, handleDialogClose, courseStatus }) => {
   const params = useParams();
-  const { data } = useGetCourseTest({ courseId: params.courseId, enabled: dialogOpen });
+  const { data } = useGetCourseTest({
+    courseId: params.courseId,
+    enabled: dialogOpen && courseStatus === COURSE_STATUSES.started,
+  });
   const timeout = data && data[0].test.timeout;
 
   return (

--- a/frontend/src/pages/LearningCourse/LearningCourse.tsx
+++ b/frontend/src/pages/LearningCourse/LearningCourse.tsx
@@ -44,6 +44,7 @@ interface LearningProps {
   material: string;
   materialType: string;
   videoPreview: string | boolean;
+  courseStatus: string;
 }
 
 const LearningCourse: React.FC<LearningProps> = ({
@@ -61,6 +62,7 @@ const LearningCourse: React.FC<LearningProps> = ({
   handleClickDialogOpen,
   handleDialogClose,
   videoPreview,
+  courseStatus,
 }) => (
   <AuthorizedLayout pageName="Learning course">
     <LearningPageContainer>
@@ -109,7 +111,11 @@ const LearningCourse: React.FC<LearningProps> = ({
               <StartTestButton variant="contained" onClick={handleClickDialogOpen}>
                 Start the Test
               </StartTestButton>
-              <FormDialog dialogOpen={dialogOpen} handleDialogClose={handleDialogClose} />
+              <FormDialog
+                dialogOpen={dialogOpen}
+                handleDialogClose={handleDialogClose}
+                courseStatus={courseStatus}
+              />
             </>
           ) : (
             <NextButton variant="contained" onClick={stageForward}>

--- a/frontend/src/pages/LearningCourse/LearningCourseContainer.tsx
+++ b/frontend/src/pages/LearningCourse/LearningCourseContainer.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from 'react';
 import { useParams } from 'react-router';
 
 import useGetClientCourseInfo from 'api/myCourses/getMyCourseInfo';
+import { useStartClientCourse } from 'api/myCourses';
 import { optimizeLink } from 'utils/helpers/videoPlayer/videoLink';
 import { getPreviewId } from 'utils/helpers/videoPlayer/getPreviewId';
 import { MATERIAL } from 'constants/materials';
@@ -24,6 +25,7 @@ const LearningCourseContainer: React.FC = () => {
   const params = useParams();
 
   const { data, isLoading } = useGetClientCourseInfo(params.courseId);
+  useStartClientCourse(params.courseId);
 
   const maxStage = data ? data.course.materials.length : MAX_STAGE_INITIAL;
 

--- a/frontend/src/pages/LearningCourse/LearningCourseContainer.tsx
+++ b/frontend/src/pages/LearningCourse/LearningCourseContainer.tsx
@@ -2,12 +2,14 @@ import React, { useEffect, useState } from 'react';
 import { useParams } from 'react-router';
 
 import useGetClientCourseInfo from 'api/myCourses/getMyCourseInfo';
+import usePassClientCourse from 'api/myCourses/passClientCourse';
 import { useStartClientCourse } from 'api/myCourses';
 import { optimizeLink } from 'utils/helpers/videoPlayer/videoLink';
 import { getPreviewId } from 'utils/helpers/videoPlayer/getPreviewId';
 import { MATERIAL } from 'constants/materials';
 import { defineMaterialType } from 'utils/helpers/defineMaterialType';
 import Loader from 'components/Loader';
+import { COURSE_STATUSES } from 'constants/statuses';
 
 import LearningCourse from './LearningCourse';
 
@@ -24,10 +26,16 @@ const LearningCourseContainer: React.FC = () => {
 
   const params = useParams();
 
-  const { data, isLoading } = useGetClientCourseInfo(params.courseId);
-  useStartClientCourse(params.courseId);
+  const { data: clientCourseResponse, isLoading } = useGetClientCourseInfo(params.courseId);
 
-  const maxStage = data ? data.course.materials.length : MAX_STAGE_INITIAL;
+  useStartClientCourse({
+    courseId: params.courseId,
+    enabled: clientCourseResponse?.status === COURSE_STATUSES.approved,
+  });
+
+  const maxStage = clientCourseResponse
+    ? clientCourseResponse.course.materials.length
+    : MAX_STAGE_INITIAL;
 
   useEffect(() => {
     if (stage > MIN_STAGE) {
@@ -42,12 +50,19 @@ const LearningCourseContainer: React.FC = () => {
     }
   }, [stage, maxStage]);
 
+  const { mutate } = usePassClientCourse(params.courseId);
+
+  const handlePassCourseStage = (courseStage: number) => {
+    mutate(courseStage);
+  };
+
   const stageForward = () => {
     if (stage < maxStage) {
       if (stage + STAGE_CHANGE === maxStage && !testEnabled) {
         setTestEnabled(true);
       }
       setStage(stage + STAGE_CHANGE);
+      handlePassCourseStage(stage);
     }
   };
   const stageBack = () => {
@@ -56,16 +71,16 @@ const LearningCourseContainer: React.FC = () => {
     }
   };
 
-  const courseDescription = data?.course.description
-    ? { title: data?.course.title, info: data?.course.description }
+  const courseDescription = clientCourseResponse?.course.description
+    ? { title: clientCourseResponse?.course.title, info: clientCourseResponse?.course.description }
     : undefined;
 
-  const materialType = data
-    ? defineMaterialType(data.course.materials[stage - 1].content[CONTENT_ELEMENT])
+  const materialType = clientCourseResponse
+    ? defineMaterialType(clientCourseResponse.course.materials[stage - 1].content[CONTENT_ELEMENT])
     : MATERIAL.text;
   const material =
-    materialType === MATERIAL.video && data
-      ? optimizeLink(data.course.materials[stage - 1].content[CONTENT_ELEMENT])
+    materialType === MATERIAL.video && clientCourseResponse
+      ? optimizeLink(clientCourseResponse.course.materials[stage - 1].content[CONTENT_ELEMENT])
       : MATERIAL.text;
   const videoPreview = getPreviewId(material);
 
@@ -73,6 +88,7 @@ const LearningCourseContainer: React.FC = () => {
 
   const handleClickDialogOpen = () => {
     setDialogOpen(true);
+    handlePassCourseStage(stage);
   };
 
   const handleDialogClose = () => {
@@ -82,12 +98,11 @@ const LearningCourseContainer: React.FC = () => {
   if (isLoading) {
     return <Loader color="primary" />;
   }
-
   return (
     <>
-      {data && (
+      {clientCourseResponse && (
         <LearningCourse
-          key={data.course.materials[stage - 1]._id}
+          key={clientCourseResponse.course.materials[stage - 1]._id}
           stage={stage}
           maxStage={maxStage}
           stageBack={stageBack}
@@ -102,6 +117,7 @@ const LearningCourseContainer: React.FC = () => {
           handleClickDialogOpen={handleClickDialogOpen}
           handleDialogClose={handleDialogClose}
           videoPreview={videoPreview}
+          courseStatus={clientCourseResponse?.status}
         />
       )}
     </>

--- a/frontend/src/pages/PassingTest/PassingTestContainer.tsx
+++ b/frontend/src/pages/PassingTest/PassingTestContainer.tsx
@@ -11,16 +11,16 @@ import ConfirmLeavePage from './ConfirmLeavePage';
 const PassingTestContainer: React.FC = () => {
   const params = useParams();
 
-  const { data: courseData, isLoading } = useGetCourseTest({ courseId: params.courseId });
+  const { data: courseTestData, isLoading } = useGetCourseTest({ courseId: params.courseId });
 
   useStartCourseTest({
     courseId: params.courseId,
-    enabled: Boolean(courseData?.length),
+    enabled: Boolean(courseTestData?.length),
   });
 
   const { mutate, data: responseData } = useSendTestResult({ courseId: params.courseId });
 
-  const courseTest = courseData?.length ? courseData[0].test : undefined;
+  const courseTest = courseTestData?.length ? courseTestData[0].test : undefined;
   const maxStage = courseTest ? courseTest.questions.length : MAX_STAGE_INITIAL;
 
   const [stage, setStage] = useState(1);
@@ -52,7 +52,6 @@ const PassingTestContainer: React.FC = () => {
       setStage(stage - STAGE_CHANGE);
     }
   };
-
   const resultEnabled = stage === maxStage;
   const questionStageItem = courseTest?.questions[stage - 1];
 

--- a/frontend/src/pages/PassingTest/PassingTestContainer.tsx
+++ b/frontend/src/pages/PassingTest/PassingTestContainer.tsx
@@ -39,7 +39,10 @@ const PassingTestContainer: React.FC = () => {
   const handleSubmitResult = () => {
     const resultData = {
       testId: courseTest?._id,
-      answers: Object.entries(values).map(([key, value]) => ({ qN: key, aN: value })),
+      answers: Object.entries(values).map(([key, value]) => ({
+        qN: Number(key),
+        aN: Number(value),
+      })),
     };
     mutate(resultData, { onSuccess: () => setTestResultPageEnabled(true) });
   };

--- a/frontend/src/pages/PassingTest/TestResult/TestResult.tsx
+++ b/frontend/src/pages/PassingTest/TestResult/TestResult.tsx
@@ -22,7 +22,12 @@ import {
   TestSkillsBox,
 } from './styled';
 
-const TestResult: React.FC<ITestResult> = ({ isFailed, responseData, percentageValue }) => (
+const TestResult: React.FC<ITestResult> = ({
+  isFailed,
+  responseData,
+  percentageValue,
+  handleFinishCourse,
+}) => (
   <AuthorizedLayout pageName="Test Result">
     <TestResultBox>
       <TestResultTitle>Your Score</TestResultTitle>
@@ -74,7 +79,9 @@ const TestResult: React.FC<ITestResult> = ({ isFailed, responseData, percentageV
         </ResultBox>
       </ContentBox>
       <ButtonBox>
-        <SubmitButton variant="medium">Submit</SubmitButton>
+        <SubmitButton onClick={handleFinishCourse} variant="medium">
+          Submit
+        </SubmitButton>
       </ButtonBox>
     </TestResultBox>
   </AuthorizedLayout>

--- a/frontend/src/pages/PassingTest/TestResult/TestResultContainer.tsx
+++ b/frontend/src/pages/PassingTest/TestResult/TestResultContainer.tsx
@@ -3,16 +3,22 @@ import { useParams } from 'react-router';
 
 import { ITestResult } from 'types/test';
 import { PERCENTAGE, TEST_STATUS } from 'constants/test';
+import { COURSE_STATUSES } from 'constants/statuses';
 import useFinishClientCourse from 'api/myCourses/finishClientCourse';
+import useGetClientCourseInfo from 'api/myCourses/getMyCourseInfo';
 
 import TestResult from './TestResult';
 
 const TestResultContainer: React.FC<ITestResult> = ({ responseData }) => {
   const params = useParams();
-  const { mutate } = useFinishClientCourse(params.courseId);
+
+  const { data: courseData } = useGetClientCourseInfo(params.courseId);
+  const { mutate } = useFinishClientCourse(courseData?._id);
 
   const handleFinishCourse = () => {
-    mutate(params.courseId);
+    if (courseData?.status === COURSE_STATUSES.testing) {
+      mutate(params.courseId);
+    }
   };
 
   const testStatus = responseData ? responseData.result.testStatus : undefined;

--- a/frontend/src/pages/PassingTest/TestResult/TestResultContainer.tsx
+++ b/frontend/src/pages/PassingTest/TestResult/TestResultContainer.tsx
@@ -1,16 +1,31 @@
 import React from 'react';
+import { useParams } from 'react-router';
 
 import { ITestResult } from 'types/test';
 import { PERCENTAGE, TEST_STATUS } from 'constants/test';
+import useFinishClientCourse from 'api/myCourses/finishClientCourse';
 
 import TestResult from './TestResult';
 
 const TestResultContainer: React.FC<ITestResult> = ({ responseData }) => {
+  const params = useParams();
+  const { mutate } = useFinishClientCourse(params.courseId);
+
+  const handleFinishCourse = () => {
+    mutate(params.courseId);
+  };
+
   const testStatus = responseData ? responseData.result.testStatus : undefined;
   const isFailed = testStatus === TEST_STATUS.notPassed;
   const percentageValue = responseData ? responseData?.result?.result * PERCENTAGE : undefined;
+
   return (
-    <TestResult isFailed={isFailed} responseData={responseData} percentageValue={percentageValue} />
+    <TestResult
+      isFailed={isFailed}
+      responseData={responseData}
+      percentageValue={percentageValue}
+      handleFinishCourse={handleFinishCourse}
+    />
   );
 };
 

--- a/frontend/src/pages/PassingTest/TestResult/TestResultContainer.tsx
+++ b/frontend/src/pages/PassingTest/TestResult/TestResultContainer.tsx
@@ -5,18 +5,16 @@ import { ITestResult } from 'types/test';
 import { PERCENTAGE, TEST_STATUS } from 'constants/test';
 import { COURSE_STATUSES } from 'constants/statuses';
 import useFinishClientCourse from 'api/myCourses/finishClientCourse';
-import useGetClientCourseInfo from 'api/myCourses/getMyCourseInfo';
 
 import TestResult from './TestResult';
 
-const TestResultContainer: React.FC<ITestResult> = ({ responseData }) => {
+const TestResultContainer: React.FC<ITestResult> = ({ responseData, status }) => {
   const params = useParams();
 
-  const { data: courseData } = useGetClientCourseInfo(params.courseId);
-  const { mutate } = useFinishClientCourse(courseData?._id);
+  const { mutate } = useFinishClientCourse(params.courseId);
 
   const handleFinishCourse = () => {
-    if (courseData?.status === COURSE_STATUSES.testing) {
+    if (status === COURSE_STATUSES.testing) {
       mutate(params.courseId);
     }
   };

--- a/frontend/src/themeSettings.ts
+++ b/frontend/src/themeSettings.ts
@@ -85,6 +85,20 @@ const theme = createTheme(
             },
           },
           {
+            props: { variant: 'completed' },
+            style: {
+              textTransform: 'none',
+              border: 'none',
+              fontWeight: '500',
+              fontFamily: globalTheme.typography.fontFamily,
+              backgroundColor: 'transparent',
+              color: '#727272',
+              letterSpacing: '-0.4px',
+              textAlign: 'center',
+              boxShadow: 'none',
+            },
+          },
+          {
             props: { variant: 'mediumContained' },
             style: {
               textTransform: 'none',

--- a/frontend/src/types/test.ts
+++ b/frontend/src/types/test.ts
@@ -54,6 +54,14 @@ export interface IResponseData {
   updatedSkills: [];
 }
 
+export interface IPassingTestResponse {
+  acknowledged: boolean;
+  modifiedCount: number;
+  upsertedId: null;
+  upsertedCount: number;
+  matchedCount: number;
+}
+
 export interface ITestResult {
   responseData: IResponseData | undefined;
   status?: string;

--- a/frontend/src/types/test.ts
+++ b/frontend/src/types/test.ts
@@ -60,6 +60,7 @@ export interface ITestResult {
   isFailed?: boolean;
   skills?: ISkills[];
   percentageValue?: number | undefined;
+  handleFinishCourse?: () => void;
 }
 
 export interface IPassingTestProps {


### PR DESCRIPTION
**Overview:**

> 1. Implemented startClientCourse API request, so now course status changes from 'approved' to 'started'
> 2. Implemented finishClientCourse API request, so now course status changes from 'testing' to 'completed' in case of successful test passing on 'Submit' button click
> 3. Implemented passClientCourse API request, so now an error '"Can not start test till course stages haven't been passed." is fixed
> 4. Fixed an error causing that the percentage of test completion didn't count
> 5. Added "Completed" button instead of a "Start the course" button on the Courses list page's card if the course is completed (V1-096)