### PR TITLE
V1-120 & V1-114 Bugfix "Details" page

### DIFF
--- a/frontend/src/components/Course/styled.ts
+++ b/frontend/src/components/Course/styled.ts
@@ -317,7 +317,7 @@ export const CourseInfoBox = styled(Box)<InfoContainerTypes>(({ type }) => ({
   ...(type === INFO.similarCourses && {
     display: 'block',
   }),
-    ...(type === INFO.searchCourses && {
+  ...(type === INFO.searchCourses && {
     height: 'auto !important',
   }),
   paddingLeft: '15px !important',

--- a/frontend/src/components/ProgressBar/ProgressBar.tsx
+++ b/frontend/src/components/ProgressBar/ProgressBar.tsx
@@ -11,7 +11,7 @@ interface ProgressProps {
   text?: string;
   size?: string;
   trailColor?: string;
-  variant?: string;
+  variant?: string | boolean;
 }
 
 const PROGRESS_COLOR = '#1BC02C';
@@ -21,6 +21,7 @@ const VARIANTS = {
   completed: 'completed',
   failed: 'failed',
   mobileCourse: 'mobileCourse',
+  successful: 'successful',
 };
 
 const ProgressBar: React.FC<ProgressProps> = ({
@@ -59,6 +60,11 @@ const ProgressBar: React.FC<ProgressProps> = ({
           pathColor: '#1cc02c',
           trailColor: '#eaeaea',
           textSize: '24px',
+        }),
+        ...(variant === VARIANTS.successful && {
+          textColor: '#000000',
+          textSize: '12px',
+          trailColor: '#36c54480',
         }),
       })}
     />

--- a/frontend/src/components/ProgressBar/ProgressBar.tsx
+++ b/frontend/src/components/ProgressBar/ProgressBar.tsx
@@ -2,27 +2,10 @@ import React from 'react';
 import 'react-circular-progressbar/dist/styles.css';
 import { buildStyles, CircularProgressbar } from 'react-circular-progressbar';
 
+import { PROGRESS_COLOR, TEXT_COLOR, VARIANTS } from 'constants/progressBar';
+import { ProgressProps } from 'types/progressBar';
+
 import { ProgressBarBox } from './styled';
-
-interface ProgressProps {
-  value?: number;
-  color?: string;
-  textColor?: string;
-  text?: string;
-  size?: string;
-  trailColor?: string;
-  variant?: string | boolean;
-}
-
-const PROGRESS_COLOR = '#1BC02C';
-const TEXT_COLOR = '#9C9C9C';
-
-const VARIANTS = {
-  completed: 'completed',
-  failed: 'failed',
-  mobileCourse: 'mobileCourse',
-  successful: 'successful',
-};
 
 const ProgressBar: React.FC<ProgressProps> = ({
   value,

--- a/frontend/src/constants/detailedCourse.tsx
+++ b/frontend/src/constants/detailedCourse.tsx
@@ -1,3 +1,4 @@
 export const OPEN_FULL_TEXT = 'Look in full';
 export const COMPLETED_STATUS_TEXT = 'Completed';
 export const PERCENTAGE_VALUE = '0%';
+export const PROGRESS_COLOR = '#131313';

--- a/frontend/src/constants/detailedCourse.tsx
+++ b/frontend/src/constants/detailedCourse.tsx
@@ -1,8 +1,3 @@
-export const INITIAL_DETAILED_COURSE = {
-  _id: '123',
-  title: 'Test Title',
-  description:
-    'To Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like Aldus PageMaker including versions of Lorem Ipsum.To Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like Aldus PageMaker including versions of Lorem Ipsum.To Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like Aldus PageMaker including versions of Lorem Ipsum.',
-  duration: '23:40:00',
-  lessons: 20,
-};
+export const OPEN_FULL_TEXT = 'Look in full';
+export const COMPLETED_STATUS_TEXT = 'Completed';
+export const PERCENTAGE_VALUE = '0%';

--- a/frontend/src/constants/progressBar.ts
+++ b/frontend/src/constants/progressBar.ts
@@ -1,0 +1,9 @@
+export const PROGRESS_COLOR = '#1BC02C';
+export const TEXT_COLOR = '#9C9C9C';
+
+export const VARIANTS = {
+  completed: 'completed',
+  failed: 'failed',
+  mobileCourse: 'mobileCourse',
+  successful: 'successful',
+};

--- a/frontend/src/constants/statuses.ts
+++ b/frontend/src/constants/statuses.ts
@@ -13,7 +13,7 @@ export const COURSE_LABELS: { [key: string]: string } = {
   approved: 'Start the course',
   started: 'Continue',
   successful: 'Completed',
-  testing: 'Continue test',
+  testing: 'Continue the test',
   rejected: 'Declined',
   completed: 'Completed',
 };

--- a/frontend/src/pages/DetailedCourse/DetailedCourse.tsx
+++ b/frontend/src/pages/DetailedCourse/DetailedCourse.tsx
@@ -16,7 +16,12 @@ import { MobileSearch } from 'components/Layout/MobileSearch';
 import { PAGES } from 'constants/pages';
 import { INFO } from 'constants/coutseInfoTypes';
 import { COURSE_LABELS } from 'constants/statuses';
-import { COMPLETED_STATUS_TEXT, OPEN_FULL_TEXT, PERCENTAGE_VALUE } from 'constants/detailedCourse';
+import {
+  COMPLETED_STATUS_TEXT,
+  OPEN_FULL_TEXT,
+  PERCENTAGE_VALUE,
+  PROGRESS_COLOR,
+} from 'constants/detailedCourse';
 import { IDetailedCourse } from 'types/detailedCourse';
 import { VARIANTS } from 'constants/progressBar';
 
@@ -78,7 +83,7 @@ const DetailedCourse: React.FC<IDetailedCourse> = ({
           <ProgressBar
             size="large"
             text={isCourseCompleted ? COMPLETED_STATUS_TEXT : PERCENTAGE_VALUE}
-            textColor="#131313"
+            textColor={PROGRESS_COLOR}
             variant={isCourseCompleted && VARIANTS.successful}
           />
         )}

--- a/frontend/src/pages/DetailedCourse/DetailedCourse.tsx
+++ b/frontend/src/pages/DetailedCourse/DetailedCourse.tsx
@@ -16,7 +16,9 @@ import { MobileSearch } from 'components/Layout/MobileSearch';
 import { PAGES } from 'constants/pages';
 import { INFO } from 'constants/coutseInfoTypes';
 import { COURSE_LABELS } from 'constants/statuses';
+import { COMPLETED_STATUS_TEXT, OPEN_FULL_TEXT, PERCENTAGE_VALUE } from 'constants/detailedCourse';
 import { IDetailedCourse } from 'types/detailedCourse';
+import { VARIANTS } from 'constants/progressBar';
 
 import {
   BackButton,
@@ -39,8 +41,6 @@ import {
   BackLink,
   MobileSearchWrapper,
 } from './styled';
-
-const OPEN_FULL_TEXT = 'Look in full';
 
 const DetailedCourse: React.FC<IDetailedCourse> = ({
   courseData,
@@ -77,9 +77,9 @@ const DetailedCourse: React.FC<IDetailedCourse> = ({
         {isCourseApplicationSubmitted && !isCourseStatusPending && (
           <ProgressBar
             size="large"
-            text={isCourseCompleted ? 'Completed' : '0%'}
+            text={isCourseCompleted ? COMPLETED_STATUS_TEXT : PERCENTAGE_VALUE}
             textColor="#131313"
-            variant={isCourseCompleted && 'successful'}
+            variant={isCourseCompleted && VARIANTS.successful}
           />
         )}
         <DetailedCourseTitle>{courseData.title}</DetailedCourseTitle>

--- a/frontend/src/pages/DetailedCourse/DetailedCourse.tsx
+++ b/frontend/src/pages/DetailedCourse/DetailedCourse.tsx
@@ -14,8 +14,9 @@ import { buttonSpinner } from 'animations';
 import { backIconMobile } from 'icons';
 import { MobileSearch } from 'components/Layout/MobileSearch';
 import { PAGES } from 'constants/pages';
-import { Course } from 'types/course';
 import { INFO } from 'constants/coutseInfoTypes';
+import { COURSE_LABELS } from 'constants/statuses';
+import { IDetailedCourse } from 'types/detailedCourse';
 
 import {
   BackButton,
@@ -39,27 +40,9 @@ import {
   MobileSearchWrapper,
 } from './styled';
 
-interface IProps {
-  courseData: Course;
-  handleApplyCourse: (event: React.MouseEvent<Element, MouseEvent>) => void;
-  buttonId: {
-    [key: string]: string | undefined;
-  };
-  page: string;
-  id: string;
-  windowWidth: string;
-  isFullTextOpen: boolean;
-  toggleFullText: () => void;
-  isCourseStatusPending: boolean;
-  isCourseLearningDisabled: boolean;
-  isLoading?: boolean;
-  targetId?: string | undefined;
-  isCourseApplicationSubmitted?: boolean;
-}
-
 const OPEN_FULL_TEXT = 'Look in full';
 
-const DetailedCourse: React.FC<IProps> = ({
+const DetailedCourse: React.FC<IDetailedCourse> = ({
   courseData,
   handleApplyCourse,
   isLoading,
@@ -67,12 +50,14 @@ const DetailedCourse: React.FC<IProps> = ({
   buttonId,
   page,
   id,
+  status,
   windowWidth,
   isFullTextOpen,
   toggleFullText,
   isCourseApplicationSubmitted,
   isCourseStatusPending,
   isCourseLearningDisabled,
+  isCourseCompleted,
 }) => (
   <AuthorizedLayout pageName="Course">
     <DetailedCourseWrapper>
@@ -90,7 +75,12 @@ const DetailedCourse: React.FC<IProps> = ({
           <Image imageUrl={courseData.avatar} />
         </ImageWrapper>
         {isCourseApplicationSubmitted && !isCourseStatusPending && (
-          <ProgressBar size="large" text="0%" textColor="#131313" />
+          <ProgressBar
+            size="large"
+            text={isCourseCompleted ? 'Completed' : '0%'}
+            textColor="#131313"
+            variant={isCourseCompleted && 'successful'}
+          />
         )}
         <DetailedCourseTitle>{courseData.title}</DetailedCourseTitle>
         {isFullTextOpen ? (
@@ -120,13 +110,19 @@ const DetailedCourse: React.FC<IProps> = ({
             <div>
               {page === PAGES.myCourses && (
                 <Link to={`${PATHS.learnCourse}/${id}`}>
-                  <StartButton
-                    color="primary"
-                    variant="mediumContained"
-                    disabled={isCourseLearningDisabled}
-                  >
-                    Start the course
-                  </StartButton>
+                  {isCourseCompleted ? (
+                    <StartButton variant="completed" disabled>
+                      Completed
+                    </StartButton>
+                  ) : (
+                    <StartButton
+                      color="primary"
+                      variant="mediumContained"
+                      disabled={isCourseLearningDisabled}
+                    >
+                      {COURSE_LABELS[status]}
+                    </StartButton>
+                  )}
                 </Link>
               )}
               {page === PAGES.coursesList && (

--- a/frontend/src/pages/DetailedCourse/DetailedCourseContainer.tsx
+++ b/frontend/src/pages/DetailedCourse/DetailedCourseContainer.tsx
@@ -57,25 +57,29 @@ const DetailedCourseContainer: React.FC<Props> = ({ page }) => {
 
   const courseInfo = courseData && 'course' in courseData ? courseData.course : courseData;
 
-  return courseInfo && courseData ? (
-    <DetailedCourse
-      courseData={courseInfo}
-      handleApplyCourse={handleApplyCourse}
-      isLoading={isLoading}
-      buttonId={BUTTON_ID}
-      targetId={targetId}
-      page={page}
-      id={courseData._id}
-      status={courseData.status}
-      windowWidth={windowWidth}
-      isFullTextOpen={isFullTextOpen}
-      toggleFullText={toggleFullText}
-      isCourseApplicationSubmitted={isCourseApplicationSubmitted}
-      isCourseStatusPending={isCourseStatusPending}
-      isCourseCompleted={isCourseCompleted}
-      isCourseLearningDisabled={isCourseLearningDisabled}
-    />
-  ) : null;
+  return (
+    <>
+      {courseInfo && courseData && (
+        <DetailedCourse
+          courseData={courseInfo}
+          handleApplyCourse={handleApplyCourse}
+          isLoading={isLoading}
+          buttonId={BUTTON_ID}
+          targetId={targetId}
+          page={page}
+          id={courseData._id}
+          status={courseData.status}
+          windowWidth={windowWidth}
+          isFullTextOpen={isFullTextOpen}
+          toggleFullText={toggleFullText}
+          isCourseApplicationSubmitted={isCourseApplicationSubmitted}
+          isCourseStatusPending={isCourseStatusPending}
+          isCourseCompleted={isCourseCompleted}
+          isCourseLearningDisabled={isCourseLearningDisabled}
+        />
+      )}
+    </>
+  );
 };
 
 export default DetailedCourseContainer;

--- a/frontend/src/pages/DetailedCourse/DetailedCourseContainer.tsx
+++ b/frontend/src/pages/DetailedCourse/DetailedCourseContainer.tsx
@@ -34,6 +34,9 @@ const DetailedCourseContainer: React.FC<Props> = ({ page }) => {
         COURSE_STATUSES.completed,
       ].includes(courseData.status)
     : false;
+  const isCourseCompleted = courseData
+    ? [COURSE_STATUSES.successful, COURSE_STATUSES.completed].includes(courseData.status)
+    : false;
   const isCourseStatusPending = courseData?.status === COURSE_STATUSES.pending;
 
   const toggleFullText = () => {
@@ -63,11 +66,13 @@ const DetailedCourseContainer: React.FC<Props> = ({ page }) => {
       targetId={targetId}
       page={page}
       id={courseData._id}
+      status={courseData.status}
       windowWidth={windowWidth}
       isFullTextOpen={isFullTextOpen}
       toggleFullText={toggleFullText}
       isCourseApplicationSubmitted={isCourseApplicationSubmitted}
       isCourseStatusPending={isCourseStatusPending}
+      isCourseCompleted={isCourseCompleted}
       isCourseLearningDisabled={isCourseLearningDisabled}
     />
   ) : null;

--- a/frontend/src/pages/DetailedCourse/styled.ts
+++ b/frontend/src/pages/DetailedCourse/styled.ts
@@ -205,31 +205,27 @@ export const BackButton = styled(Button)({
 export const StartButton = styled(Button)({
   height: '50px',
   width: '150px',
-  [theme.breakpoints.up('xs')]: {
-    height: '44px',
-    width: '131px',
-    fontSize: '14px !important',
-    lineHeight: '19px',
-    padding: '10px 10px!important',
-    margin: '24px 18px 0px calc(100% - 156px) !important',
-  },
-  [theme.breakpoints.up('md')]: {
-    height: '35px',
-    width: '105px',
+  fontSize: '18px !important',
+  fontWeight: '700 !important',
+  [theme.breakpoints.down('xl')]: {
     fontSize: '12px !important',
-    padding: '4px 5px!important',
-    margin: '0px 20px 0px calc(100% - 132px) !important',
-  },
-  [theme.breakpoints.up('lg')]: {
     height: '37px',
     width: '112px',
-    fontSize: '12px !important',
-    margin: '0px 50px 0px calc(100% - 162px) !important',
+    padding: '4px 5px !important',
+    margin: '0 50px 0 calc(100% - 162px) !important',
   },
-  [theme.breakpoints.up('xl')]: {
-    height: '50px !important',
-    width: '150px !important',
-    fontSize: '18px !important',
+  [theme.breakpoints.down('lg')]: {
+    height: '35px',
+    width: '105px',
+    margin: '0 20px 0 calc(100% - 132px) !important',
+  },
+  [theme.breakpoints.down('md')]: {
+    height: '44px',
+    width: '131px',
+    lineHeight: '19px',
+    fontSize: '14px!important',
+    padding: '10px !important',
+    margin: '24px 18px 0 calc(100% - 156px) !important',
   },
 });
 

--- a/frontend/src/pages/MyCourses/styled.ts
+++ b/frontend/src/pages/MyCourses/styled.ts
@@ -142,6 +142,7 @@ export const ContinueTestButton = styled(Button)({
     padding: '12px 0px!important',
   },
 });
+
 export const MobileSearchWrapper = styled('div')({
   width: '100%',
   margin: '16px 0px 8px 0px',
@@ -155,9 +156,9 @@ export const MobileSearchWrapper = styled('div')({
 export const CompletedButton = styled(Button)({
   height: '50px',
   width: '150px',
-  fontSize: '16px!important',
+  fontSize: '16px !important',
   lineHeight: '22px',
-  padding: '12px 12px!important',
+  padding: '12px !important',
   justifySelf: 'flex-start',
   alignSelf: 'center',
   display: 'flex',

--- a/frontend/src/types/detailedCourse.ts
+++ b/frontend/src/types/detailedCourse.ts
@@ -1,0 +1,21 @@
+import { Course } from './course';
+
+export interface IDetailedCourse {
+  courseData: Course;
+  handleApplyCourse: (event: React.MouseEvent<Element, MouseEvent>) => void;
+  buttonId: {
+    [key: string]: string | undefined;
+  };
+  page: string;
+  id: string;
+  status: string;
+  windowWidth: string;
+  isFullTextOpen: boolean;
+  toggleFullText: () => void;
+  isCourseStatusPending: boolean;
+  isCourseLearningDisabled: boolean;
+  isLoading?: boolean;
+  targetId?: string | undefined;
+  isCourseApplicationSubmitted?: boolean;
+  isCourseCompleted?: boolean;
+}

--- a/frontend/src/types/progressBar.ts
+++ b/frontend/src/types/progressBar.ts
@@ -1,0 +1,9 @@
+export interface ProgressProps {
+  value?: number;
+  color?: string;
+  textColor?: string;
+  text?: string;
+  size?: string;
+  trailColor?: string;
+  variant?: string | boolean;
+}


### PR DESCRIPTION
**Overview:** 
1. If the user has completed the test, on the "Details" page the text in the percentage completion area changed to "Completed" and the button changed  to "Completed" and disabled instead of "Start the course"
2. The name of the button on the Details page changed to the same as on the "My courses" page
3. Added a "successful" progress bar variant to use on the "Details" page in case of successful course completion.
4. Moved Detailed course and ProgressBar interfaces to the types folder
5. Removed Detailed course mocked data from constants