### PR TITLE
V1-120 fixed button displaying on the Details page

### DIFF
--- a/frontend/src/pages/DetailedCourse/DetailedCourse.tsx
+++ b/frontend/src/pages/DetailedCourse/DetailedCourse.tsx
@@ -122,19 +122,21 @@ const DetailedCourse: React.FC<IDetailedCourse> = ({
                   </ContinueTestButton>
                 </Link>
               ) : (
-                <Link to={`${PATHS.learnCourse}/${id}`}>
-                  {isCourseCompleted ? (
-                    <></>
-                  ) : (
-                    <StartButton
-                      color="primary"
-                      variant="mediumContained"
-                      disabled={isCourseLearningDisabled}
-                    >
-                      {COURSE_LABELS[status]}
-                    </StartButton>
-                  )}
-                </Link>
+                page === PAGES.myCourses && (
+                  <Link to={`${PATHS.learnCourse}/${id}`}>
+                    {isCourseCompleted ? (
+                      <></>
+                    ) : (
+                      <StartButton
+                        color="primary"
+                        variant="mediumContained"
+                        disabled={isCourseLearningDisabled}
+                      >
+                        {COURSE_LABELS[status]}
+                      </StartButton>
+                    )}
+                  </Link>
+                )
               )}
               {page === PAGES.coursesList && (
                 <StartButton


### PR DESCRIPTION
**Overview:**
When the user clicks on the Details button on the Courses list (not client courses), two buttons were displayed on the Details page, it was fixed and now only one button is displaying