### PR TITLE
V1/146 | Fixed menu for admin role

### DIFF
--- a/frontend/src/constants/menuRoles.tsx
+++ b/frontend/src/constants/menuRoles.tsx
@@ -75,11 +75,6 @@ const ADMIN_MENU: Array<MenuItemProps> = [
     title: 'Skills',
     icon: <Icon fontSize="large" component={skillsIcon} />,
   },
-  {
-    path: PATHS.help,
-    title: 'Help',
-    icon: <Icon fontSize="large" component={helpIcon} />,
-  },
 ];
 
 export const ROLES_MENU: IRolesMenu = {


### PR DESCRIPTION
There was an implemented menu for admin already i just removed 'help' tab as it shown in design