### PR TITLE
Feature/v1-145 | Fixed bug with videos not played.

### DIFF
--- a/frontend/src/utils/helpers/videoPlayer/videoLink.ts
+++ b/frontend/src/utils/helpers/videoPlayer/videoLink.ts
@@ -1,5 +1,7 @@
+const INDEX_NOT_FOUND = -1;
+
 export const optimizeLink = (link: string): string => {
   const shortenTo = link.indexOf('&');
-  const optimizedLink = link.slice(0, shortenTo);
+  const optimizedLink = shortenTo === INDEX_NOT_FOUND ? link : link.slice(0, shortenTo);
   return optimizedLink;
 };


### PR DESCRIPTION
# Overview
>
> Despite the fact, that we thought the problem was in video duration, it actually was in links optimization.

# Changes 
>
> Changed `optimizeLink` helper logics. Now optimization is not performed when it is not necessary.

#  How to test
>
> Run your local apps on this PR's branch (backend with `dev` mode), authorize as `user` and go to "QA for everyone" course in `MyCourses` page. I've added new temporal stage with long-duration video there. It seems to work now.

> P.S.
> It was the shortest bugfix I have ever had on this project, but I've spent several hours on it.