### PR TITLE
 Bugfix/v1-129 Requests page styles 

### DIFF
--- a/frontend/src/components/Avatar/styled.ts
+++ b/frontend/src/components/Avatar/styled.ts
@@ -76,5 +76,9 @@ export const UserAvatarRounded = styled('div')<Size>(({ size, avatar }) => ({
       width: '50px',
       height: '50px',
     }),
+    ...(size === SIZE.small && {
+      width: '50px',
+      height: '50px',
+    }),
   },
 }));

--- a/frontend/src/pages/Requests/RequestItem/styled.ts
+++ b/frontend/src/pages/Requests/RequestItem/styled.ts
@@ -16,8 +16,8 @@ export const ImageWrapper = styled('div')({
 
 export const CourseImageWrapper = styled('div')({
   margin: '2px 8px 0 35px !important',
-  height: '14.25px',
-  width: '19px',
+  height: '20px',
+  width: '30px',
 });
 
 export const Text = styled('p')({
@@ -77,11 +77,12 @@ export const SecondaryText = styled(Text)<IStatus>(({ status }) => ({
 }));
 
 export const ActionButton = styled(Button)({
-  height: '32px',
+  height: '34px',
   width: '64px',
   '&.MuiButton-root': {
     fontWeight: '400',
-    fontSize: '14px',
+    fontSize: '16px',
+    lineHeight: '14px',
   },
   [theme.breakpoints.down('xl')]: {
     marginLeft: '10px !important',
@@ -89,14 +90,13 @@ export const ActionButton = styled(Button)({
   [theme.breakpoints.down(1200)]: {
     '&.MuiButton-root': {
       fontSize: '12px',
-      lineHeight: '10px',
     },
   },
 });
 
 export const InterviewActionButton = styled(ActionButton)({
-  height: '32px',
-  width: '158px',
+  height: '34px',
+  width: '165px',
   '&.MuiButton-root': {
     padding: '0',
   },

--- a/frontend/src/pages/Requests/Requests.tsx
+++ b/frontend/src/pages/Requests/Requests.tsx
@@ -1,12 +1,10 @@
 import React from 'react';
-import { Grid } from '@mui/material';
 
 import Loader from 'components/Loader';
 import { NoContent } from 'components/NoContent';
 import { AuthorizedLayout } from 'components/Layout';
 import { LOADER } from 'constants/loaderTypes';
 import { NO_REQUESTS } from 'constants/messages';
-import { SIZE } from 'constants/sizes';
 import { IRequestsProps } from 'types/request';
 
 import RequestItem from './RequestItem';
@@ -22,33 +20,29 @@ const Requests: React.FC<IRequestsProps> = ({
   declineLoading,
 }) => (
   <AuthorizedLayout pageName="Requests">
-    <RequestsWrapper>
-      {isLoading ? (
-        <Loader color="primary" type={LOADER.content} />
-      ) : (
-        <Grid container>
-          {requests?.length ? (
-            requests.map((request) => {
-              const isTargetRequest = targetId === request._id;
-              return (
-                <RequestItem
-                  key={request._id}
-                  request={request}
-                  approveRequest={approveRequest}
-                  approveLoading={approveLoading}
-                  declineRequest={declineRequest}
-                  declineLoading={declineLoading}
-                  isTargetRequest={isTargetRequest}
-                  status={request.status}
-                />
-              );
-            })
-          ) : (
-            <NoContent message={NO_REQUESTS} size={SIZE.medium} />
-          )}
-        </Grid>
-      )}
-    </RequestsWrapper>
+    {isLoading ? (
+      <Loader color="primary" type={LOADER.content} />
+    ) : requests?.length ? (
+      <RequestsWrapper container>
+        {requests.map((request) => {
+          const isTargetRequest = targetId === request._id;
+          return (
+            <RequestItem
+              key={request._id}
+              request={request}
+              approveRequest={approveRequest}
+              approveLoading={approveLoading}
+              declineRequest={declineRequest}
+              declineLoading={declineLoading}
+              isTargetRequest={isTargetRequest}
+              status={request.status}
+            />
+          );
+        })}
+      </RequestsWrapper>
+    ) : (
+      <NoContent message={NO_REQUESTS} />
+    )}
   </AuthorizedLayout>
 );
 

--- a/frontend/src/pages/Requests/styled.ts
+++ b/frontend/src/pages/Requests/styled.ts
@@ -1,9 +1,9 @@
+import { Grid } from '@mui/material';
 import styled from 'styled-components';
 
-export const RequestsWrapper = styled('div')({
+export const RequestsWrapper = styled(Grid)({
   padding: '40px 30px',
   fontFamily: 'Ubuntu',
-  height: 'calc(100% - 100px)',
   maxWidth: '1800px',
   width: '100%',
 });


### PR DESCRIPTION
**Overview:**
Fixed the next issues:
1. On devices with a resolution of 1441px or more, the user's avatar is large
2. The size of the course image should be 30x20
3. The font size of the buttons "Apply", "Accept with interview", "Reject" should be 16px
4. The size of the "Accept" and "Reject" buttons should be 64x34px, the size of the "Accept with interview" button should be 165x34px
5. The "No requests" text should be displayed in the middle of the screen (should have the same styles as "No courses yet" on the My courses page)