### PR TITLE
bug/v1-170 | Fixed redirect if test time is over

### DIFF
--- a/frontend/src/pages/PassingTest/PassingTestContainer.tsx
+++ b/frontend/src/pages/PassingTest/PassingTestContainer.tsx
@@ -86,6 +86,7 @@ const PassingTestContainer: React.FC = () => {
   const handleCloseTimeIsOverDialog = () => {
     setTestTimeoutDialogOpen();
     handleSubmitResult();
+    naviagteTo(`${PATHS.myCourses}/${params.courseId}`);
   };
 
   const stageBack = () => {


### PR DESCRIPTION
When the user failed the test in the allotted time, a modal window is displayed
 when the user closes this window (via "OK" button or cross icon), he is redirected to the course page with result