### PR TITLE
bug/V1-182 | Changed the label btn to 'Continue' if user failed the test

### DIFF
--- a/frontend/src/components/Button/HOC/withDisable.tsx
+++ b/frontend/src/components/Button/HOC/withDisable.tsx
@@ -19,7 +19,6 @@ const withDisable =
           COURSE_STATUSES.completed,
           COURSE_STATUSES.successful,
           COURSE_STATUSES.assessment,
-          COURSE_STATUSES.failed,
         ].includes(status)
       ) {
         setDisable(true);

--- a/frontend/src/constants/statuses.ts
+++ b/frontend/src/constants/statuses.ts
@@ -19,7 +19,7 @@ export const COURSE_LABELS: { [key: string]: string } = {
   rejected: 'Declined',
   completed: 'Completed',
   assessment: 'Assessment',
-  failed: 'Failed',
+  failed: 'Continue',
 };
 
 export const NOTIFICATION_STATUSES = {


### PR DESCRIPTION
Fixed: When user failed the test, then the "Failed" button is displayed on the My Courses page and on the Details page.
Result: "Continue' button displayed on the My Course page and on the Details page