### PR TITLE
Bug/v1-070 | Fixed responsive design for My Course

### DIFF
--- a/frontend/src/components/Button/styled.ts
+++ b/frontend/src/components/Button/styled.ts
@@ -26,4 +26,7 @@ export const CustomButton = styled(Button)({
 
 export const ButtonsWrapper = styled('div')({
   display: 'flex',
+  [theme.breakpoints.down('md')]: {
+    marginTop: '20px',
+  },
 });

--- a/frontend/src/components/Course/styled.ts
+++ b/frontend/src/components/Course/styled.ts
@@ -227,9 +227,8 @@ export const CourseDescription = styled('p')<InfoContainerTypes>(
 
 export const InfoContainer = styled(Box)<InfoContainerTypes>(({ type }) => ({
   display: 'flex',
-  height: '30px',
-  alignItems: 'end !important',
-  alignSelf: 'end !important',
+  alignItems: 'start !important',
+  alignSelf: 'self-end',
   paddingBottom: '0px !important',
   [theme.breakpoints.down('xl')]: {
     ...(type !== INFO.detailedCourse &&
@@ -238,13 +237,11 @@ export const InfoContainer = styled(Box)<InfoContainerTypes>(({ type }) => ({
       }),
     ...(type !== INFO.searchCourses && {
       marginLeft: '10px',
-      height: '50px',
     }),
   },
   [theme.breakpoints.down('lg')]: {
     display: 'block',
-    alignItems: 'end !important',
-    alignSelf: 'end !important',
+    alignItems: 'start !important',
     height: 'fit-content',
   },
   [theme.breakpoints.down('md')]: {
@@ -257,17 +254,20 @@ export const InfoContainer = styled(Box)<InfoContainerTypes>(({ type }) => ({
     }),
   },
   [theme.breakpoints.down(550)]: {
-    display: 'block',
+    ...(type === INFO.detailedCourse && {
+      flexDirection: 'column',
+    }),
   },
   [theme.breakpoints.down('sm')]: {
     display: 'flex',
     ...(type === INFO.detailedCourse && {
       marginLeft: '8px',
+      flexDirection: 'row',
     }),
   },
   [theme.breakpoints.up('xl')]: {
     display: 'block',
-    width: '220px',
+    // width: '220px',
     ...(type !== INFO.searchCourses && {
       marginLeft: '15px',
     }),
@@ -301,9 +301,6 @@ export const InfoItem = styled('div')({
 });
 
 export const InfoItemText = styled(Typography)({
-  [theme.breakpoints.down('xl')]: {
-    width: '70px',
-  },
   [theme.breakpoints.down('md')]: {
     lineHeight: '18px!important',
   },
@@ -372,7 +369,7 @@ export const CourseInfoBox = styled(Box)<InfoContainerTypes>(({ type }) => ({
   flexDirection: 'row',
   paddingLeft: '15px !important',
   paddingBottom: '0px !important',
-  height: '50px !important',
+  // height: '50px !important',
 }));
 
 export const MobileCourseInfoBox = styled(Box)({

--- a/frontend/src/pages/CoursesList/styled.ts
+++ b/frontend/src/pages/CoursesList/styled.ts
@@ -52,6 +52,7 @@ export const CourseActions = styled('div')({
 
 export const CourseActionsBox = styled(Box)({
   margin: '0 15px 0 8px',
+  marginTop: '20px',
 });
 
 export const MobileLink = styled(Link)({

--- a/frontend/src/pages/DetailedCourse/DetailedCourse.tsx
+++ b/frontend/src/pages/DetailedCourse/DetailedCourse.tsx
@@ -91,7 +91,7 @@ const DetailedCourse: React.FC<IProps> = ({
           <DetailedCourseTextMobile>{commonCourseData.description}</DetailedCourseTextMobile>
         ) : (
           <DetailedCourseTextMobile>
-            {commonCourseData.description.slice(0, 140)}
+            {commonCourseData.description.slice(0, 70).concat('...')}
             <ButtonFullText onClick={toggleFullText}>
               {!isFullTextOpen && OPEN_FULL_TEXT}
             </ButtonFullText>

--- a/frontend/src/pages/DetailedCourse/DetailedCourse.tsx
+++ b/frontend/src/pages/DetailedCourse/DetailedCourse.tsx
@@ -91,10 +91,10 @@ const DetailedCourse: React.FC<IProps> = ({
           <DetailedCourseTextMobile>{commonCourseData.description}</DetailedCourseTextMobile>
         ) : (
           <DetailedCourseTextMobile>
-            {commonCourseData.description.slice(0, 70).concat('...')}
-            <ButtonFullText onClick={toggleFullText}>
-              {!isFullTextOpen && OPEN_FULL_TEXT}
-            </ButtonFullText>
+            {commonCourseData.description.slice(0, 140).concat('...')}
+            {Number(commonCourseData.description.length) > 140 && (
+              <ButtonFullText onClick={toggleFullText}>{OPEN_FULL_TEXT}</ButtonFullText>
+            )}
           </DetailedCourseTextMobile>
         )}
         <DetailedCourseText>{commonCourseData.description}</DetailedCourseText>

--- a/frontend/src/pages/DetailedCourse/styled.ts
+++ b/frontend/src/pages/DetailedCourse/styled.ts
@@ -41,7 +41,7 @@ export const ImageWrapper = styled('div')<Image>(({ imageUrl }) => {
     [theme.breakpoints.up('md')]: {
       width: '281px',
       height: '147px',
-      margin: '5px 25px 105px 0',
+      margin: '5px 25px 30px 0',
       borderRadius: '8px',
     },
     [theme.breakpoints.up('xl')]: {

--- a/frontend/src/pages/DetailedCourse/styled.ts
+++ b/frontend/src/pages/DetailedCourse/styled.ts
@@ -121,21 +121,22 @@ export const DetailedCourseTitle = styled(Typography)({
 });
 
 export const DetailedCourseActionsBox = styled(Box)({
+  width: '100%',
   display: 'flex',
+  alignItems: 'center',
   justifyContent: 'space-between',
   marginTop: '50px',
-  [theme.breakpoints.up('xs')]: {
+  [theme.breakpoints.down('sm')]: {
     display: 'block',
     marginTop: '24px',
     marginLeft: '3px',
   },
-  [theme.breakpoints.up('md')]: {
-    display: 'flex',
-    justifyContent: 'space-between',
+  [theme.breakpoints.down('md')]: {
     marginTop: '56px',
     marginLeft: '0',
   },
   [theme.breakpoints.up('lg')]: {
+    width: 'initial',
     minWidth: '60vw',
   },
 });

--- a/frontend/src/pages/DetailedCourse/styled.ts
+++ b/frontend/src/pages/DetailedCourse/styled.ts
@@ -135,10 +135,6 @@ export const DetailedCourseActionsBox = styled(Box)({
     marginTop: '56px',
     marginLeft: '0',
   },
-  [theme.breakpoints.up('lg')]: {
-    width: 'initial',
-    minWidth: '60vw',
-  },
 });
 
 export const SimilarCoursesWrapper = styled(Grid)({


### PR DESCRIPTION
1. Fixed:  In mobile devices from 400px or less the button on the "Details" page should have the margin-top 20px
2 Fixed: In devices from 401px or more the button on the "Details" page should be displayed on the right side of the screen as on the 1920x1080
3 .Fixed: If the whole text is displayed without using the "Look in full" link, this link shouldn't be displayed
4. Fixed:  The time of the course should be displayed in one line on the "Details" page and on the course card. And the "Details" and the second button on the course card shouldn't be moved
5. Fixed: in devices from 1440px to 770px, the margin-bottom of the image should be 30px on the "Details" page