### PR TITLE
V1-076 Bugfix: fixed app routes for correct pages displaying

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -53,6 +53,13 @@ const App: React.FC = () => (
               element={
                 <RoleRoute roles={[ROLE.manager]}>
                   <Employees />
+                </RoleRoute>
+              }
+            />
+            <Route
+              path={PATHS.employeeProfile}
+              element={
+                <RoleRoute roles={[ROLE.manager]}>
                   <EmployeeProfile />
                 </RoleRoute>
               }


### PR DESCRIPTION
**Fixed the following issue:**
1. Not found page was opened instead of Employees and EmployeeProfile pages. The 500 error displayed