### PR TITLE
Improve/v1-161 | Added ability to update course title and avatar.

### DIFF
--- a/backend/src/controllers/admin/editCourse.ts
+++ b/backend/src/controllers/admin/editCourse.ts
@@ -7,6 +7,7 @@ import { NextFunction, Request, Response } from 'express';
 import { IUpdateCourseBody } from 'interfaces/ICourses/IQueryCourses';
 import { addMaterialStages } from 'utils/normaliser/materials';
 import { setAnswerProperNumbersToQuestions } from 'utils/normaliser/test';
+import isValidAvatar from 'utils/validation/isValidAvatar';
 import isValidDescription from 'utils/validation/isValidDescription';
 import isValidMaterials from 'utils/validation/isValidMaterials';
 import isValidQuestions from 'utils/validation/isValidQuestions';
@@ -38,6 +39,16 @@ const editCourse = async (
         dataToUpdate.description,
       );
       updatedData.description = description;
+    }
+
+    const isAvatarValid = isValidAvatar(dataToUpdate.avatar);
+    if (isAvatarValid) {
+      const { avatar } = await updateCourseField(
+        courseId,
+        COURSE_FIELDS.avatar,
+        dataToUpdate.avatar,
+      );
+      updatedData.avatar = avatar;
     }
 
     const isMaterialsValid = isValidMaterials(dataToUpdate.materials);

--- a/backend/src/controllers/admin/editCourse.ts
+++ b/backend/src/controllers/admin/editCourse.ts
@@ -11,6 +11,7 @@ import isValidDescription from 'utils/validation/isValidDescription';
 import isValidMaterials from 'utils/validation/isValidMaterials';
 import isValidQuestions from 'utils/validation/isValidQuestions';
 import isValidTechnologies from 'utils/validation/isValidTechnologies';
+import isValidTitle from 'utils/validation/isValidTitle';
 
 const editCourse = async (
   req: Request<{ id: string }, never, IUpdateCourseBody>,
@@ -22,6 +23,12 @@ const editCourse = async (
     const dataToUpdate = req.body;
 
     const updatedData: IUpdateCourseBody = {};
+
+    const isTitleValid = isValidTitle(dataToUpdate.title);
+    if (isTitleValid) {
+      const { title } = await updateCourseField(courseId, COURSE_FIELDS.title, dataToUpdate.title);
+      updatedData.title = title;
+    }
 
     const isDescriptionValid = isValidDescription(dataToUpdate.description);
     if (isDescriptionValid) {

--- a/backend/src/db/models/Course.ts
+++ b/backend/src/db/models/Course.ts
@@ -12,6 +12,7 @@ const courseSchema = new Schema<ICourse>({
   complexity: { type: Number, required: true },
   materials: [{ stage: { type: Number }, content: [{ type: String }] }],
   test: { type: Schema.Types.ObjectId, ref: 'Test' },
+  avatar: { type: String, required: true },
 });
 
 const CourseModel = model<ICourse>('Courses', courseSchema, 'courses');

--- a/backend/src/interfaces/ICourses/IQueryCourses.ts
+++ b/backend/src/interfaces/ICourses/IQueryCourses.ts
@@ -29,6 +29,8 @@ interface IProgress {
 }
 
 interface IUpdateCourseBody {
+  title?: string;
+  avatar?: string;
   description?: string;
   skills?: {
     skill: string;

--- a/backend/src/interfaces/ICourses/IQueryCourses.ts
+++ b/backend/src/interfaces/ICourses/IQueryCourses.ts
@@ -29,9 +29,9 @@ interface IProgress {
 }
 
 interface IUpdateCourseBody {
-  title?: string;
-  avatar?: string;
-  description?: string;
+  title?: ICourse['title'];
+  avatar?: ICourse['avatar'];
+  description?: ICourse['description'];
   skills?: {
     skill: string;
     points: number;

--- a/backend/src/interfaces/Ientities/Icourses.ts
+++ b/backend/src/interfaces/Ientities/Icourses.ts
@@ -11,7 +11,7 @@ interface ICourse {
   description: string;
   materials: { stage: number; content: Array<string> }[];
   test: ObjectId;
-  avatar?: string;
+  avatar: string;
 }
 
 type TCourses = Array<ICourse>;

--- a/backend/src/utils/validation/isValidAvatar.ts
+++ b/backend/src/utils/validation/isValidAvatar.ts
@@ -1,0 +1,13 @@
+/* eslint-disable no-useless-escape */
+
+import { IUpdateCourseBody } from 'interfaces/ICourses/IQueryCourses';
+
+const LINK_PATTERN =
+  /^https?:\/\/(www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b([-a-zA-Z0-9()@:%_\+.~#?&//=]*)$/i;
+
+const isLink = (link: string): boolean => LINK_PATTERN.test(link);
+
+const isValidAvatar = (avatar: IUpdateCourseBody['avatar']): boolean =>
+  Boolean(avatar && typeof avatar === 'string' && isLink(avatar));
+
+export default isValidAvatar;

--- a/backend/src/utils/validation/isValidTitle.ts
+++ b/backend/src/utils/validation/isValidTitle.ts
@@ -1,6 +1,6 @@
 import { IUpdateCourseBody } from 'interfaces/ICourses/IQueryCourses';
 
-const isValidTitle = (description: IUpdateCourseBody['title']): boolean =>
-  Boolean(description && typeof description === 'string');
+const isValidTitle = (title: IUpdateCourseBody['title']): boolean =>
+  Boolean(title && typeof title === 'string');
 
 export default isValidTitle;

--- a/backend/src/utils/validation/isValidTitle.ts
+++ b/backend/src/utils/validation/isValidTitle.ts
@@ -1,0 +1,6 @@
+import { IUpdateCourseBody } from 'interfaces/ICourses/IQueryCourses';
+
+const isValidTitle = (description: IUpdateCourseBody['title']): boolean =>
+  Boolean(description && typeof description === 'string');
+
+export default isValidTitle;


### PR DESCRIPTION
# Changes

Added new functionality to endpoint `[PUT] /api/courses/:id/edit` :
1. Now you can additionally pass title or avatar fields to update existing course. Example:
```
{
    "avatar": "https://imageio.forbes.com/specials-images/imageserve/5faad4255239c9448d6c7bcd/Best-Animal-Photos-Contest--Close-Up-Of-baby-monkey/960x0.jpg?fit=bounds&format=jpg&width=960",
    "title": "DAPO TESTS PURPOSE",
    "description": "UPDATED TWICE",
    ...
}
```
2. Also some minor models and interfaces changes.