### PR TITLE
V1-076 ProgressBar styles on Employee profile courses 

### DIFF
--- a/frontend/src/components/ProgressBar/ProgressBar.tsx
+++ b/frontend/src/components/ProgressBar/ProgressBar.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import 'react-circular-progressbar/dist/styles.css';
 import { buildStyles, CircularProgressbar } from 'react-circular-progressbar';
 
-import { PROGRESS_COLOR, TEXT_COLOR, VARIANTS } from 'constants/progressBar';
+import { PROGRESS_COLOR, TEXT_COLOR, TRAIL_COLOR, VARIANTS } from 'constants/progressBar';
 import { ProgressProps } from 'types/progressBar';
 
 import { ProgressBarBox } from './styled';
@@ -25,7 +25,7 @@ const ProgressBar: React.FC<ProgressProps> = ({
         textSize: '14px',
         textColor: textColor || TEXT_COLOR,
         pathColor: color || PROGRESS_COLOR,
-        trailColor: trailColor || '#d6d6d6',
+        trailColor: trailColor || TRAIL_COLOR,
         ...(variant === VARIANTS.completed && {
           textColor: '#000000',
           pathColor: '#9be2a2',
@@ -36,10 +36,20 @@ const ProgressBar: React.FC<ProgressProps> = ({
           pathColor: '#eaeaea',
           trailColor: '#eaeaea',
         }),
+        ...(variant === VARIANTS.employeeNotStarted && {
+          textColor: '#000000',
+          pathColor: '#d6d6d6',
+          trailColor: '#d6d6d6',
+        }),
         ...(variant === VARIANTS.failed && {
           textColor: '#000000',
           pathColor: '#ff9494',
           trailColor: '#ff9494',
+        }),
+        ...(variant === VARIANTS.employeeFailed && {
+          textColor: '#000000',
+          pathColor: '#d43e41',
+          trailColor: '#d43e41',
         }),
         ...(variant === VARIANTS.failedWithPercentage && {
           textColor: '#000000',

--- a/frontend/src/constants/progressBar.ts
+++ b/frontend/src/constants/progressBar.ts
@@ -1,10 +1,13 @@
 export const PROGRESS_COLOR = '#1BC02C';
 export const TEXT_COLOR = '#9C9C9C';
+export const TRAIL_COLOR = '#D6D6D6';
 
 export const VARIANTS = {
   notStarted: 'notStarted',
+  employeeNotStarted: 'employeeNotStarted',
   completed: 'completed',
   failed: 'failed',
+  employeeFailed: 'employeeFailed',
   successful: 'successful',
   failedWithPercentage: 'failedWithPercentage',
   successfulWithPercentage: 'successfulWithPercentage',

--- a/frontend/src/pages/EmployeeProfile/EmployeeSkillsAndCourses/EmployeeCourses/EmployeeCoursesList/EmployeeCoursesList.tsx
+++ b/frontend/src/pages/EmployeeProfile/EmployeeSkillsAndCourses/EmployeeCourses/EmployeeCoursesList/EmployeeCoursesList.tsx
@@ -5,8 +5,8 @@ import NoContent from 'components/NoContent';
 import { NO_USER_COURSES } from 'constants/messages';
 import { SIZE } from 'constants/sizes';
 import { IEmployeeCoursesList } from 'types/employee';
-import { countProgress } from 'utils/helpers/countCourseProgress';
 import { setFirstLetterUppercase } from 'utils/helpers/setFirstLetterUppercase';
+import { convertEmployeeCourseProgress } from 'utils/helpers/convertCourseStatusToProgress';
 
 import {
   CourseItemText,
@@ -23,10 +23,11 @@ const EmployeeCoursesList: React.FC<IEmployeeCoursesList> = ({ courses }) => (
     {courses?.length ? (
       courses.map((course, id, coursesArray) => {
         const isDividerVisible = id < coursesArray.length - 1;
+        const { progressValue, progressVariant } = convertEmployeeCourseProgress(course.status);
         return (
           <div key={course.course.title}>
             <CoursesListItem>
-              <ProgressBar size={SIZE.small} value={countProgress(course.progress)} />
+              <ProgressBar size={SIZE.small} value={progressValue} variant={progressVariant} />
               <CourseItemText>
                 <CourseTitle>{course.course.title}</CourseTitle>
                 <CourseStatus>{setFirstLetterUppercase(course.status)}</CourseStatus>

--- a/frontend/src/utils/helpers/convertCourseStatusToProgress.ts
+++ b/frontend/src/utils/helpers/convertCourseStatusToProgress.ts
@@ -5,8 +5,8 @@ import { TEST_STATUS } from 'constants/test';
 
 export interface ConvertedProgress {
   progressValue: number;
-  progressText: string;
   progressVariant: string;
+  progressText?: string;
 }
 
 const convertCourseStatusToProgress = (status?: string): ConvertedProgress => {
@@ -77,4 +77,44 @@ const convertTestStatusToProgress = (
   return convertedValues[status] ?? defaultConvertedValue;
 };
 
-export { convertCourseStatusToProgress, convertTestStatusToProgress };
+const convertEmployeeCourseProgress = (status?: string): ConvertedProgress => {
+  const defaultConvertedValue = {
+    progressValue: 0,
+    progressVariant: VARIANTS.employeeNotStarted,
+  };
+
+  if (!status) {
+    return defaultConvertedValue;
+  }
+
+  const convertedValues = {
+    [COURSE_STATUSES.started]: {
+      progressValue: 37,
+      progressVariant: VARIANTS.successfulWithPercentage,
+    },
+    [COURSE_STATUSES.testing]: {
+      progressValue: 80,
+      progressVariant: VARIANTS.successfulWithPercentage,
+    },
+    [COURSE_STATUSES.completed]: {
+      progressValue: 100,
+      progressVariant: VARIANTS.successfulWithPercentage,
+    },
+    [COURSE_STATUSES.assessment]: {
+      progressValue: 100,
+      progressVariant: VARIANTS.successfulWithPercentage,
+    },
+    [COURSE_STATUSES.failed]: {
+      progressValue: 0,
+      progressVariant: VARIANTS.employeeFailed,
+    },
+  };
+
+  return convertedValues[status] ?? defaultConvertedValue;
+};
+
+export {
+  convertCourseStatusToProgress,
+  convertTestStatusToProgress,
+  convertEmployeeCourseProgress,
+};


### PR DESCRIPTION
**Overview:**

> 1. Added convertEmployeeCourseProgress helper, cause on Employee page the styles are different
> 2. Added ProgressBar variants: employeeNotStarted and employeeFailed
> 3. Moved default TRAIL_COLOR to constants
> 4. Fixed ProgressBar styles on Employee courses page according to QA review

<img width="255" alt="image" src="https://user-images.githubusercontent.com/44285339/163398784-5591750c-d8f8-4744-bd59-774032367a82.png">
<img width="244" alt="image" src="https://user-images.githubusercontent.com/44285339/163398822-ab202ca7-b9ed-414b-8904-61f00f6f108d.png">
