### PR TITLE
V1-194 Bugfix: When a manager assigns courses to a user, these courses are displayed only after the page is refreshed

### DIFF
--- a/frontend/src/pages/EmployeeProfile/EmployeeProfile.tsx
+++ b/frontend/src/pages/EmployeeProfile/EmployeeProfile.tsx
@@ -20,6 +20,7 @@ const EmployeeProfile: React.FC<IEmployeeProfile> = ({
   toggleProfileInfoOpened,
   isSkillOpened,
   isCourseOpened,
+  refetchEmployeeProfile,
 }) => (
   <AuthorizedLayout pageName="Employee">
     <EmployeeProfileWrapper>
@@ -37,6 +38,7 @@ const EmployeeProfile: React.FC<IEmployeeProfile> = ({
         employeeInfo={employeeInfo}
         toggleEmployeeInfo={toggleEmployeeInfo}
         toggleHover={toggleHover}
+        refetchEmployeeProfile={refetchEmployeeProfile}
         isSkillOpened={isSkillOpened}
         isCourseOpened={isCourseOpened}
       />

--- a/frontend/src/pages/EmployeeProfile/EmployeeProfileContainer.tsx
+++ b/frontend/src/pages/EmployeeProfile/EmployeeProfileContainer.tsx
@@ -8,7 +8,9 @@ import EmployeeProfile from './EmployeeProfile';
 
 const EmployeeProfileContainer: React.FC = () => {
   const params = useParams();
-  const { data: employeeResponse } = useGetEmployeeProfile(params.employeeId);
+  const { data: employeeResponse, refetch: refetchEmployeeProfile } = useGetEmployeeProfile(
+    params.employeeId,
+  );
 
   const [employeeInfo, setEmployeeInfo] = useState(EMPLOYEE_INFO.skills);
   const [hoveredButton, setHoveredButton] = useState<string | undefined>(undefined);
@@ -44,6 +46,7 @@ const EmployeeProfileContainer: React.FC = () => {
       toggleProfileInfoOpened={toggleProfileInfoOpened}
       isSkillOpened={isSkillOpened}
       isCourseOpened={isCourseOpened}
+      refetchEmployeeProfile={refetchEmployeeProfile}
     />
   );
 };

--- a/frontend/src/pages/EmployeeProfile/EmployeeSkillsAndCourses/AddCourseButton/AddCourseButton.tsx
+++ b/frontend/src/pages/EmployeeProfile/EmployeeSkillsAndCourses/AddCourseButton/AddCourseButton.tsx
@@ -8,14 +8,23 @@ import { StyledButton } from './styled';
 interface IProps {
   isAddCourseDialogOpen: boolean;
   toggleAddCourseDiaologOpen: () => void;
+  refetchEmployeeProfile: () => void;
 }
 
-const AddCourseButton: FC<IProps> = ({ isAddCourseDialogOpen, toggleAddCourseDiaologOpen }) => (
+const AddCourseButton: FC<IProps> = ({
+  isAddCourseDialogOpen,
+  toggleAddCourseDiaologOpen,
+  refetchEmployeeProfile,
+}) => (
   <>
     <StyledButton variant="medium" onClick={toggleAddCourseDiaologOpen}>
       {ButtonLabels.addCourse}
     </StyledButton>
-    <AddCourseDialog isOpened={isAddCourseDialogOpen} handleClose={toggleAddCourseDiaologOpen} />
+    <AddCourseDialog
+      isOpened={isAddCourseDialogOpen}
+      handleClose={toggleAddCourseDiaologOpen}
+      refetchEmployeeProfile={refetchEmployeeProfile}
+    />
   </>
 );
 

--- a/frontend/src/pages/EmployeeProfile/EmployeeSkillsAndCourses/AddCourseButton/AddCourseButtonContainer.tsx
+++ b/frontend/src/pages/EmployeeProfile/EmployeeSkillsAndCourses/AddCourseButton/AddCourseButtonContainer.tsx
@@ -4,13 +4,18 @@ import { useToggle } from 'hooks';
 
 import AddCourseButton from './AddCourseButton';
 
-const AddCourseButtonContainer: FC = () => {
+interface IAddCourseButtonContainer {
+  refetchEmployeeProfile: () => void;
+}
+
+const AddCourseButtonContainer: FC<IAddCourseButtonContainer> = ({ refetchEmployeeProfile }) => {
   const [isAddCourseDialogOpen, setAddCourseDialogOpen] = useToggle();
 
   return (
     <AddCourseButton
       isAddCourseDialogOpen={isAddCourseDialogOpen}
       toggleAddCourseDiaologOpen={setAddCourseDialogOpen}
+      refetchEmployeeProfile={refetchEmployeeProfile}
     />
   );
 };

--- a/frontend/src/pages/EmployeeProfile/EmployeeSkillsAndCourses/AddCourseButton/AddCourseDialog/AddCourseDialogContainer.tsx
+++ b/frontend/src/pages/EmployeeProfile/EmployeeSkillsAndCourses/AddCourseButton/AddCourseDialog/AddCourseDialogContainer.tsx
@@ -12,9 +12,14 @@ import AddCourseDialog from './AddCourseDialog';
 export interface IProps {
   isOpened: boolean;
   handleClose: () => void;
+  refetchEmployeeProfile: () => void;
 }
 
-const AddCourseDialogContainer: FC<IProps> = ({ handleClose, ...otherProps }) => {
+const AddCourseDialogContainer: FC<IProps> = ({
+  handleClose,
+  refetchEmployeeProfile,
+  ...otherProps
+}) => {
   const { employeeId } = useParams();
 
   const [searchInputValue, setSearchInputValue] = useState('');
@@ -35,12 +40,17 @@ const AddCourseDialogContainer: FC<IProps> = ({ handleClose, ...otherProps }) =>
     handleClose();
   };
 
+  const handleSuccessAddCourse = () => {
+    handleDialogClose();
+    refetchEmployeeProfile();
+  };
+
   const { mutate: addCourseToEmployee, isLoading: isAddCourseToEmployeeLoading } =
     useAddCourseToEmployee({
       courseIdsList: selectedCoursesList.map(({ _id }) => ({
         courseId: _id,
       })),
-      onSuccess: handleDialogClose,
+      onSuccess: handleSuccessAddCourse,
     });
 
   const lastCourseRef = useFetchNextPage({ hasNextPage, fetchNextPage });

--- a/frontend/src/pages/EmployeeProfile/EmployeeSkillsAndCourses/EmployeeSkillsAndCourses.tsx
+++ b/frontend/src/pages/EmployeeProfile/EmployeeSkillsAndCourses/EmployeeSkillsAndCourses.tsx
@@ -20,6 +20,7 @@ const EmployeeSkillsAndCourses: React.FC<IEmployeeSkillsAndCourses> = ({
   employeeInfo,
   toggleEmployeeInfo,
   toggleHover,
+  refetchEmployeeProfile,
   isSkillOpened,
   isCourseOpened,
 }) => (
@@ -43,7 +44,7 @@ const EmployeeSkillsAndCourses: React.FC<IEmployeeSkillsAndCourses> = ({
           {ButtonLabels.allCourses}
         </SkillsAndCoursesButton>
       </EmployeeButtonGroup>
-      <AddCourseButton />
+      <AddCourseButton refetchEmployeeProfile={refetchEmployeeProfile} />
     </SkillsAndCoursesBox>
     <UserSkillsWrapper>
       {employeeInfo === EMPLOYEE_INFO.skills ? (

--- a/frontend/src/types/employee.ts
+++ b/frontend/src/types/employee.ts
@@ -37,6 +37,7 @@ export interface IEmployeeProfile {
   toggleHover: (buttonHovered: string) => void;
   profileInfoOpened: boolean;
   toggleProfileInfoOpened: () => void;
+  refetchEmployeeProfile: () => void;
   isSkillOpened: boolean;
   isCourseOpened: boolean;
   employeeCourses?: ClientCourse[];
@@ -65,6 +66,7 @@ export interface IEmployeeSkillsAndCourses {
   employeeInfo: string;
   toggleEmployeeInfo: (infoToOpen: string) => void;
   toggleHover: (buttonHovered: string) => void;
+  refetchEmployeeProfile: () => void;
   isSkillOpened: boolean;
   isCourseOpened: boolean;
   employeeCourses?: ClientCourse[];


### PR DESCRIPTION
**Fixed the following issue:**
1. When a manager assigns courses to the user (via modal window on the emploee's profile page), these courses are displayed only after the page is refreshed