### PR TITLE
V1-203 Bugfix: fixed SignIn form styles on responsive design

### DIFF
--- a/frontend/src/pages/SignIn/SignInForm/styled.ts
+++ b/frontend/src/pages/SignIn/SignInForm/styled.ts
@@ -194,8 +194,8 @@ export const GridSignInput = styled(Grid)<IColor>(({ color }) => ({
     border: '1px solid #B7BECA',
   },
   '@media(max-width: 1280px)': {
-    marginBottom: '16px',
     margin: 0,
+    marginBottom: '16px',
     padding: 0,
     height: '48px',
     maxHeight: '48px',


### PR DESCRIPTION
**Fixed the following issue:**

> Login and password fields are glued together on the devices where resolution from 425px to 1280px