### PR TITLE
bug/v1-195 | Fixed width for course title in Employee profile page

### DIFF
--- a/frontend/src/pages/EmployeeProfile/EmployeeSkillsAndCourses/EmployeeCourses/EmployeeCoursesList/CourseItem/styled.ts
+++ b/frontend/src/pages/EmployeeProfile/EmployeeSkillsAndCourses/EmployeeCourses/EmployeeCoursesList/CourseItem/styled.ts
@@ -32,6 +32,7 @@ export const CourseItemText = styled('div')({
 });
 
 export const CourseTitle = styled(Typography)({
+  maxWidth: '230px',
   color: '#2C2525',
   fontSize: '20px',
   lineHeight: '26px',


### PR DESCRIPTION
Fixed bug where long name went outside the bounds of the component