### PR TITLE
Bug/v1-210 | Fixed migrations issues.

### DIFF
--- a/backend/migrations-backdev/20220411135726-added-types-for-materials.js
+++ b/backend/migrations-backdev/20220411135726-added-types-for-materials.js
@@ -581,7 +581,7 @@ const MOCKED_MATERIALS = [
         stage: 1,
         content: [
           {
-            type: 'video',
+            type: 'plain',
             material:
               'Salesforce is an American company, the developer of the CRM system of the same name, provided to customers exclusively using the SaaS model. Under the name Force the company provides a PaaS system for self-development of applications, and under the brand Database — cloud database management system. Among the products acquired as a result of acquisitions are the Heroku platform service, the MuleESB service bus, the replicated Tableau data visualization system, and the Slack corporate messenger.',
           },
@@ -643,7 +643,11 @@ const MOCKED_MATERIALS = [
       {
         stage: 1,
         content: [
-          'Ruby is a dynamic, reflective, interpreted high—level programming language[8][9]. The language has an operating system-independent implementation of multithreading, strong dynamic typing, garbage collector and many other features[⇨]. In terms of syntax features, it is close to the Perl and Eiffel languages, in terms of an object-oriented approach, it is similar to Smalltalk. Also some features of the language are taken from Python, Lisp, Dylan and Club.',
+          {
+            type: 'plain',
+            material:
+              'Ruby is a dynamic, reflective, interpreted high—level programming language[8][9]. The language has an operating system-independent implementation of multithreading, strong dynamic typing, garbage collector and many other features[⇨]. In terms of syntax features, it is close to the Perl and Eiffel languages, in terms of an object-oriented approach, it is similar to Smalltalk. Also some features of the language are taken from Python, Lisp, Dylan and Club.',
+          },
         ],
       },
       {

--- a/backend/migrations/20220411150120-added-types-for-materials.js
+++ b/backend/migrations/20220411150120-added-types-for-materials.js
@@ -581,7 +581,7 @@ const MOCKED_MATERIALS = [
         stage: 1,
         content: [
           {
-            type: 'video',
+            type: 'plain',
             material:
               'Salesforce is an American company, the developer of the CRM system of the same name, provided to customers exclusively using the SaaS model. Under the name Force the company provides a PaaS system for self-development of applications, and under the brand Database — cloud database management system. Among the products acquired as a result of acquisitions are the Heroku platform service, the MuleESB service bus, the replicated Tableau data visualization system, and the Slack corporate messenger.',
           },
@@ -643,7 +643,11 @@ const MOCKED_MATERIALS = [
       {
         stage: 1,
         content: [
-          'Ruby is a dynamic, reflective, interpreted high—level programming language[8][9]. The language has an operating system-independent implementation of multithreading, strong dynamic typing, garbage collector and many other features[⇨]. In terms of syntax features, it is close to the Perl and Eiffel languages, in terms of an object-oriented approach, it is similar to Smalltalk. Also some features of the language are taken from Python, Lisp, Dylan and Club.',
+          {
+            type: 'plain',
+            material:
+              'Ruby is a dynamic, reflective, interpreted high—level programming language[8][9]. The language has an operating system-independent implementation of multithreading, strong dynamic typing, garbage collector and many other features[⇨]. In terms of syntax features, it is close to the Perl and Eiffel languages, in terms of an object-oriented approach, it is similar to Smalltalk. Also some features of the language are taken from Python, Lisp, Dylan and Club.',
+          },
         ],
       },
       {


### PR DESCRIPTION
# Changes

- added missed content `type` and `material` fields to Ruby course material element.
- replaced Salesforce course material type with `plain` instead of `video`.