### PR TITLE
Bugfix | V1-206 - Fixed content overflow for phone and skype column at Employee page

### DIFF
--- a/frontend/src/components/TextTooltip/TextTooltip.tsx
+++ b/frontend/src/components/TextTooltip/TextTooltip.tsx
@@ -1,0 +1,11 @@
+import { FC } from 'react';
+
+import { ITextTooltipProps } from './types';
+import { TooltipWrapper, Tooltip } from './styled';
+
+const TextTooltip: FC<ITextTooltipProps> = ({ children }) => (
+  <TooltipWrapper>
+    <Tooltip content={children}>{children}</Tooltip>
+  </TooltipWrapper>
+);
+export default TextTooltip;

--- a/frontend/src/components/TextTooltip/index.ts
+++ b/frontend/src/components/TextTooltip/index.ts
@@ -1,0 +1,1 @@
+export { default } from './TextTooltip';

--- a/frontend/src/components/TextTooltip/styled.ts
+++ b/frontend/src/components/TextTooltip/styled.ts
@@ -1,0 +1,23 @@
+import { styled } from '@mui/material';
+
+import { ITooltipProps } from './types';
+
+export const TooltipWrapper = styled('div')({
+  position: 'relative',
+});
+
+export const Tooltip = styled('p')<ITooltipProps>(({ content }) => ({
+  margin: 0,
+  overflow: 'hidden',
+  textOverflow: 'ellipsis',
+  '&:hover:after': {
+    position: 'absolute',
+    content: `"${content}"`,
+    bottom: '-30px',
+    left: 0,
+    padding: '4px 8px',
+    fontSize: '12px',
+    color: '#FFF',
+    background: '#000',
+  },
+}));

--- a/frontend/src/components/TextTooltip/types.ts
+++ b/frontend/src/components/TextTooltip/types.ts
@@ -1,0 +1,7 @@
+export interface ITooltipProps {
+  content?: string;
+}
+
+export interface ITextTooltipProps {
+  children?: string;
+}

--- a/frontend/src/enums/employee.ts
+++ b/frontend/src/enums/employee.ts
@@ -19,5 +19,7 @@ export enum EmployeeColumnName {
   empty = '',
   rank = 'rank',
   stack = 'stack',
+  phone = 'phone',
+  skype = 'skype',
   button = 'button',
 }

--- a/frontend/src/pages/Employees/EmployeesList/EmployeeContent/EmployeeContent.tsx
+++ b/frontend/src/pages/Employees/EmployeesList/EmployeeContent/EmployeeContent.tsx
@@ -1,6 +1,7 @@
 import { FC } from 'react';
 
 import Avatar from 'components/Avatar';
+import TextTooltip from 'components/TextTooltip';
 import { EmployeeRank, EmployeeContentType, EmployeeColumnName } from 'enums/employee';
 import { Size } from 'enums/sizes';
 import { IEmployeeContentProps } from 'pages/Employees/types';
@@ -28,10 +29,10 @@ const EmployeeContent: FC<IEmployeeContentProps> = ({
   handleShowButtonClick,
 }) => {
   const { avatar, firstName, lastName, position } = employee;
-  const contentIsVisible = isVisible || type !== EmployeeContentType.hidden;
+  const isContentVisible = isVisible || type !== EmployeeContentType.hidden;
 
   return (
-    <ContentGrid contentType={type} isVisible={contentIsVisible}>
+    <ContentGrid contentType={type} isVisible={isContentVisible}>
       {config.map((columnName) => (
         <ContentColumn key={columnName} columnName={columnName} contentType={type}>
           {type === EmployeeContentType.hidden && <ColumnLabel>{columnName}</ColumnLabel>}
@@ -52,6 +53,10 @@ const EmployeeContent: FC<IEmployeeContentProps> = ({
               employee[columnName].map((stackItem) => (
                 <StackItem key={stackItem.member.name}>{stackItem.member.name}</StackItem>
               ))
+            ) : (columnName === EmployeeColumnName.phone ||
+                columnName === EmployeeColumnName.skype) &&
+              type !== EmployeeContentType.hidden ? (
+              <TextTooltip>{employee[columnName]}</TextTooltip>
             ) : columnName === EmployeeColumnName.button ? (
               <StyledExpandMoreIcon isVisible={isVisible} onClick={handleShowButtonClick} />
             ) : (


### PR DESCRIPTION
- Frontend

1. Fixed content overflow for phone and skype column at Employee page
2. Added reusable component TextTooltip

![image](https://user-images.githubusercontent.com/61495158/166633316-3316f79a-ba70-4fe6-a063-71affe618015.png)
