### PR TITLE
Feature/V1-250 | Implemented get test admin API.

### DIFF
--- a/backend/src/controllers/admin/getTest.ts
+++ b/backend/src/controllers/admin/getTest.ts
@@ -1,0 +1,18 @@
+import { NextFunction } from 'express';
+
+import { getTestById } from 'db/providers/testProvider';
+import { TGetTestRequest, TGetTestResponse } from 'interfaces/requests/tests/getTest';
+
+const getTest = async (req: TGetTestRequest, res: TGetTestResponse, next: NextFunction) => {
+  try {
+    const { id: testId } = req.params;
+
+    const test = await getTestById(testId);
+
+    res.json(test);
+  } catch (error) {
+    next(error);
+  }
+};
+
+export default getTest;

--- a/backend/src/db/providers/testProvider.ts
+++ b/backend/src/db/providers/testProvider.ts
@@ -42,8 +42,15 @@ const getTestProvider = async (courseId: string) => {
   return test;
 };
 
-const getTestById = async (testId: string | ObjectId): Promise<ITest> =>
-  TestModel.findById(testId).lean();
+const getTestById = async (testId: string | ObjectId): Promise<ITest> => {
+  const test = await TestModel.findById(testId).select('-__v').lean();
+
+  if (!test) {
+    throw new NotFoundError('Test was not found.');
+  }
+
+  return test;
+};
 
 const getTrueAnswersProvider = async (testId: string) => {
   const trueAnswers = await TestModel.findOne(

--- a/backend/src/enums/routesEnum.ts
+++ b/backend/src/enums/routesEnum.ts
@@ -6,7 +6,7 @@ enum Routes {
   clientCourses = '/clientCourses',
   materials = '/materials',
   pendingCourses = '/pendingCourses',
-  test = '/test',
+  tests = '/tests',
   employees = '/employees',
   skills = '/skills',
 }
@@ -20,6 +20,7 @@ enum SubRoutes {
   getTestResult = '/:id/test/result',
   startTest = '/:id/test/start',
   getCourseTest = '/:id/test',
+  getTest = '/:id',
   startCourse = '/:id/start',
   updateCourse = '/:id/edit',
   createCourse = '/create',

--- a/backend/src/interfaces/requests/tests/getTest.d.ts
+++ b/backend/src/interfaces/requests/tests/getTest.d.ts
@@ -1,0 +1,13 @@
+import { Request, Response } from 'express';
+
+import { ITest } from 'interfaces/Ientities/Itest';
+
+type TGetTestRequestParams = {
+  id: string;
+};
+
+type TGetTestRequest = Request<TGetTestRequestParams>;
+
+type TGetTestResponse = Response<ITest>;
+
+export { TGetTestRequest, TGetTestResponse };

--- a/backend/src/routing/routes.ts
+++ b/backend/src/routing/routes.ts
@@ -9,6 +9,7 @@ import clientCoursesRouter from './clientCoursesRouter';
 import pendingCoursesRouter from './pendingCourses';
 import employeesRouter from './employeesRouter';
 import skillsRouter from './skillsRouter';
+import testsRouter from './testsRouter';
 
 const routers = Router();
 
@@ -19,5 +20,6 @@ routers.use(`${Routes.users}`, userRouter);
 routers.use(`${Routes.courses}`, coursesRouter);
 routers.use(`${Routes.employees}`, employeesRouter);
 routers.use(`${Routes.skills}`, skillsRouter);
+routers.use(`${Routes.tests}`, testsRouter);
 
 export default routers;

--- a/backend/src/routing/testsRouter.ts
+++ b/backend/src/routing/testsRouter.ts
@@ -1,0 +1,12 @@
+import { Router } from 'express';
+
+import { USER_ROLES } from 'config/constants';
+import { SubRoutes } from 'enums/routesEnum';
+import withAuth from 'middlewares/authMiddleware';
+import getTest from 'controllers/admin/getTest';
+
+const testsRouter = Router();
+
+testsRouter.get(SubRoutes.getTest, withAuth([USER_ROLES.ADMIN]), getTest);
+
+export default testsRouter;


### PR DESCRIPTION
# Changes

New endpoint `[GET] /api/tests/:id` for ADMIN role only. Responses with test data. `:id` is test's `_id`.