### PR TITLE
bug/Fixed Skill components for admin

### DIFF
--- a/frontend/src/pages/Skills/SkillGroup/SkillGroup.tsx
+++ b/frontend/src/pages/Skills/SkillGroup/SkillGroup.tsx
@@ -1,23 +1,30 @@
 import { FC, memo } from 'react';
 
-import { TSkillGroupProps } from 'pages/Skills/types';
-
+import NoContent from 'components/NoContent';
+import { NO_SKILLS } from 'constants/messages';
 import SkillItem from './SkillItem';
-import { SkillsGroupWrapper, SkillsTitle, SkillsBox, SkillsDivider } from './styled';
+import { TSkillGroupProps } from '../types';
+import { SkillsGroupWrapper, SkillsTitle, SkillsBox, SkillsDivider, NoSkills } from './styled';
 
 const SkillGroup: FC<TSkillGroupProps> = ({ skillFounded }) => (
   <>
-    {skillFounded?.map(({ name: skillsGroupName, skills: skillsGroup }) => (
-      <SkillsGroupWrapper key={skillsGroupName}>
-        <SkillsTitle>{skillsGroupName}</SkillsTitle>
-        <SkillsBox>
-          {skillsGroup.map(({ name: skillName, image: skillImage }) => (
-            <SkillItem key={skillName} name={skillName} skillImage={skillImage} />
-          ))}
-        </SkillsBox>
-        <SkillsDivider />
-      </SkillsGroupWrapper>
-    ))}
+    {skillFounded?.length ? (
+      skillFounded.map(({ name: skillsGroupName, skills: skillsGroup }) => (
+        <SkillsGroupWrapper key={skillsGroupName}>
+          <SkillsTitle>{skillsGroupName}</SkillsTitle>
+          <SkillsBox>
+            {skillsGroup.map(({ name: skillName, image: skillImage }) => (
+              <SkillItem key={skillName} name={skillName} skillImage={skillImage} />
+            ))}
+          </SkillsBox>
+          <SkillsDivider />
+        </SkillsGroupWrapper>
+      ))
+    ) : (
+      <NoSkills>
+        <NoContent message={NO_SKILLS} />
+      </NoSkills>
+    )}
   </>
 );
 

--- a/frontend/src/pages/Skills/SkillGroup/SkillGroup.tsx
+++ b/frontend/src/pages/Skills/SkillGroup/SkillGroup.tsx
@@ -1,29 +1,23 @@
 import { FC, memo } from 'react';
 
-import NoContent from 'components/NoContent';
-import { NO_SKILLS } from 'constants/messages';
+import { TSkillGroupProps } from 'pages/Skills/types';
 
-import { SkillsGroupWrapper, SkillsTitle, SkillsBox, SkillsDivider } from './styled';
 import SkillItem from './SkillItem';
-import { TSkillGroupProps } from '../types';
+import { SkillsGroupWrapper, SkillsTitle, SkillsBox, SkillsDivider } from './styled';
 
 const SkillGroup: FC<TSkillGroupProps> = ({ skillFounded }) => (
   <>
-    {skillFounded?.length ? (
-      skillFounded.map(({ name: skillsGroupName, skills: skillsGroup }) => (
-        <SkillsGroupWrapper key={skillsGroupName}>
-          <SkillsTitle>{skillsGroupName}</SkillsTitle>
-          <SkillsBox>
-            {skillsGroup.map(({ name: skillName, image: skillImage }) => (
-              <SkillItem key={skillName} name={skillName} skillImage={skillImage} />
-            ))}
-          </SkillsBox>
-          <SkillsDivider />
-        </SkillsGroupWrapper>
-      ))
-    ) : (
-      <NoContent message={NO_SKILLS} />
-    )}
+    {skillFounded?.map(({ name: skillsGroupName, skills: skillsGroup }) => (
+      <SkillsGroupWrapper key={skillsGroupName}>
+        <SkillsTitle>{skillsGroupName}</SkillsTitle>
+        <SkillsBox>
+          {skillsGroup.map(({ name: skillName, image: skillImage }) => (
+            <SkillItem key={skillName} name={skillName} skillImage={skillImage} />
+          ))}
+        </SkillsBox>
+        <SkillsDivider />
+      </SkillsGroupWrapper>
+    ))}
   </>
 );
 

--- a/frontend/src/pages/Skills/SkillGroup/styled.ts
+++ b/frontend/src/pages/Skills/SkillGroup/styled.ts
@@ -40,3 +40,7 @@ export const SkillsDivider = styled(Divider)({
   maxWidth: '1300px',
   width: '100%',
 });
+
+export const NoSkills = styled(Box)({
+  marginTop: '300px',
+});

--- a/frontend/src/pages/Skills/Skills.tsx
+++ b/frontend/src/pages/Skills/Skills.tsx
@@ -3,6 +3,8 @@ import { FC } from 'react';
 import PageTitle from 'components/PageTitle';
 import Loader from 'components/Loader';
 import { Loaders } from 'enums/loader';
+import NoContent from 'components/NoContent';
+import { NO_SKILLS } from 'constants/messages';
 
 import SkillGroup from './SkillGroup';
 import { ISkillsPageProps } from './types';
@@ -12,28 +14,30 @@ import {
   SearchWrapper,
   SkillsWrapper,
   StyledDivider,
+  NoSkills,
 } from './styled';
 
-const Skills: FC<ISkillsPageProps> = ({
-  skillFounded,
-  handleSearchInputChange,
-  isSkillsLoading,
-}) => (
-  <PageTitle title="Skills">
-    <SkillsPageContainer container>
-      <SkillsWrapper>
-        <SearchWrapper>
-          <SearchSkill onChange={handleSearchInputChange} />
-          <StyledDivider />
-        </SearchWrapper>
-        {isSkillsLoading ? (
-          <Loader type={Loaders.content} />
-        ) : (
-          <SkillGroup skillFounded={skillFounded} />
-        )}
-      </SkillsWrapper>
-    </SkillsPageContainer>
-  </PageTitle>
-);
+const Skills: FC<ISkillsPageProps> = ({ skillFounded, handleSearchInputChange, isSkillsLoading }) =>
+  isSkillsLoading ? (
+    <Loader type={Loaders.content} />
+  ) : (
+    <PageTitle title="Skills">
+      <SkillsPageContainer container>
+        <SkillsWrapper>
+          <SearchWrapper>
+            <SearchSkill onChange={handleSearchInputChange} />
+            <StyledDivider />
+          </SearchWrapper>
+          {skillFounded?.length ? (
+            <SkillGroup skillFounded={skillFounded} />
+          ) : (
+            <NoSkills>
+              <NoContent message={NO_SKILLS} />
+            </NoSkills>
+          )}
+        </SkillsWrapper>
+      </SkillsPageContainer>
+    </PageTitle>
+  );
 
 export default Skills;

--- a/frontend/src/pages/Skills/Skills.tsx
+++ b/frontend/src/pages/Skills/Skills.tsx
@@ -3,8 +3,6 @@ import { FC } from 'react';
 import PageTitle from 'components/PageTitle';
 import Loader from 'components/Loader';
 import { Loaders } from 'enums/loader';
-import NoContent from 'components/NoContent';
-import { NO_SKILLS } from 'constants/messages';
 
 import SkillGroup from './SkillGroup';
 import { ISkillsPageProps } from './types';
@@ -14,30 +12,28 @@ import {
   SearchWrapper,
   SkillsWrapper,
   StyledDivider,
-  NoSkills,
 } from './styled';
 
-const Skills: FC<ISkillsPageProps> = ({ skillFounded, handleSearchInputChange, isSkillsLoading }) =>
-  isSkillsLoading ? (
-    <Loader type={Loaders.content} />
-  ) : (
-    <PageTitle title="Skills">
-      <SkillsPageContainer container>
-        <SkillsWrapper>
-          <SearchWrapper>
-            <SearchSkill onChange={handleSearchInputChange} />
-            <StyledDivider />
-          </SearchWrapper>
-          {skillFounded?.length ? (
-            <SkillGroup skillFounded={skillFounded} />
-          ) : (
-            <NoSkills>
-              <NoContent message={NO_SKILLS} />
-            </NoSkills>
-          )}
-        </SkillsWrapper>
-      </SkillsPageContainer>
-    </PageTitle>
-  );
+const Skills: FC<ISkillsPageProps> = ({
+  skillFounded,
+  handleSearchInputChange,
+  isSkillsLoading,
+}) => (
+  <PageTitle title="Skills">
+    <SkillsPageContainer container>
+      <SkillsWrapper>
+        <SearchWrapper>
+          <SearchSkill onChange={handleSearchInputChange} />
+          <StyledDivider />
+        </SearchWrapper>
+        {isSkillsLoading ? (
+          <Loader type={Loaders.content} />
+        ) : (
+          <SkillGroup skillFounded={skillFounded} />
+        )}
+      </SkillsWrapper>
+    </SkillsPageContainer>
+  </PageTitle>
+);
 
 export default Skills;

--- a/frontend/src/pages/Skills/styled.ts
+++ b/frontend/src/pages/Skills/styled.ts
@@ -59,7 +59,3 @@ export const SkillsWrapper = styled(Box)({
     padding: 0,
   },
 });
-
-export const NoSkills = styled(Box)({
-  marginTop: '300px',
-});

--- a/frontend/src/pages/Skills/styled.ts
+++ b/frontend/src/pages/Skills/styled.ts
@@ -47,6 +47,7 @@ export const StyledDivider = styled(Divider)({
 });
 
 export const SkillsWrapper = styled(Box)({
+  width: '100%',
   padding: '40px',
   [theme.breakpoints.down('lg')]: {
     padding: '0 0 0 28px',
@@ -57,4 +58,8 @@ export const SkillsWrapper = styled(Box)({
   [theme.breakpoints.down('sm')]: {
     padding: 0,
   },
+});
+
+export const NoSkills = styled(Box)({
+  marginTop: '300px',
 });

--- a/frontend/src/pages/Skills/utils.ts
+++ b/frontend/src/pages/Skills/utils.ts
@@ -1,5 +1,5 @@
 const START_SYMBOL = 0;
-export const MAX_LENGTH = 25;
+export const MAX_LENGTH = 23;
 
 export const getShortedSkillName = (str: string): string => {
   return str.length > MAX_LENGTH ? `${str.slice(START_SYMBOL, MAX_LENGTH)}...` : str;


### PR DESCRIPTION
1. Checked:  The skill name should be displayed max in two lines (work correct with utils using)
2. Fixed:  the text "No skills" should be displayed in the center of the page