### PR TITLE
Bugfix/V1-260 | Fixed scheduler time diapasons and status checks.

### DIFF
--- a/backend/src/utils/schedule/updateTestStatuses.ts
+++ b/backend/src/utils/schedule/updateTestStatuses.ts
@@ -10,15 +10,14 @@ const updateTestStatuses = async (): Promise<void> => {
   try {
     await connectToDatabase();
 
-    const [from, to] = generateTestStatusToUpdateDates(UPDATE_TEST_STATUSES_TIME_RANGE);
+    const [, to] = generateTestStatusToUpdateDates(UPDATE_TEST_STATUSES_TIME_RANGE);
 
     const { modifiedCount: statusesUpdatedAmount } = await ClientCourseModel.updateMany(
       {
-        status: CourseStatus.failed,
+        status: { $in: [CourseStatus.failed, CourseStatus.testing] },
         $or: [
           {
             finishTestDate: {
-              $gte: from,
               $lte: to,
             },
           },


### PR DESCRIPTION
# Changes

1. Fixed test-ban scheduler: updating courses with statuses: `testing`, `failed`
2. Fixed test-ban scheduler: diapason changed to avoid loosing db integrity if server is down