### PR TITLE
Bug/V1-266 | Course Creator issues

### DIFF
--- a/frontend/src/components/EditorTabs/ActionButtons/ActionButtons.tsx
+++ b/frontend/src/components/EditorTabs/ActionButtons/ActionButtons.tsx
@@ -16,7 +16,6 @@ const ActionButtons: FC<IActionButtons> = ({
   isSubmitEnabled,
   formik,
   isEditCourseDataMutateLoading,
-  isCreateCourseMode,
 }) => (
   <ButtonWrapper>
     <Box>
@@ -39,11 +38,7 @@ const ActionButtons: FC<IActionButtons> = ({
         )}
       </StyledButton>
     ) : (
-      <StyledButton
-        variant="mediumContained"
-        disabled={!isCreateCourseMode && !formik?.isValid}
-        onClick={handleNextStep}
-      >
+      <StyledButton variant="mediumContained" disabled={!formik?.isValid} onClick={handleNextStep}>
         {ButtonLabels.next}
       </StyledButton>
     )}

--- a/frontend/src/components/EditorTabs/types.ts
+++ b/frontend/src/components/EditorTabs/types.ts
@@ -23,5 +23,4 @@ export interface IActionButtons {
   handleNextStep?: () => void;
   formik?: IFormik;
   isEditCourseDataMutateLoading?: boolean;
-  isCreateCourseMode?: boolean;
 }

--- a/frontend/src/constants/courseEditor.ts
+++ b/frontend/src/constants/courseEditor.ts
@@ -56,7 +56,7 @@ export const INITIAL_VALUES = {
   materials: [
     {
       type: 'video',
-      material: '',
+      material: 'Material video link',
     },
   ],
   test: {
@@ -66,12 +66,56 @@ export const INITIAL_VALUES = {
         answers: [
           {
             aN: 1,
-            variant: '',
+            variant: 'Answer',
           },
         ],
         correctAnswer: 1,
         qN: 1,
-        question: '',
+        question: 'Test question',
+      },
+      {
+        answers: [
+          {
+            aN: 1,
+            variant: 'Answer',
+          },
+        ],
+        correctAnswer: 1,
+        qN: 1,
+        question: 'Test question',
+      },
+      {
+        answers: [
+          {
+            aN: 1,
+            variant: 'Answer',
+          },
+        ],
+        correctAnswer: 1,
+        qN: 1,
+        question: 'Test question',
+      },
+      {
+        answers: [
+          {
+            aN: 1,
+            variant: 'Answer',
+          },
+        ],
+        correctAnswer: 1,
+        qN: 1,
+        question: 'Test question',
+      },
+      {
+        answers: [
+          {
+            aN: 1,
+            variant: 'Answer',
+          },
+        ],
+        correctAnswer: 1,
+        qN: 1,
+        question: 'Test question',
       },
     ],
     timeout: 500,

--- a/frontend/src/constants/courseEditor.ts
+++ b/frontend/src/constants/courseEditor.ts
@@ -55,7 +55,7 @@ export const INITIAL_VALUES = {
   ],
   materials: [
     {
-      type: '',
+      type: 'video',
       material: '',
     },
   ],

--- a/frontend/src/pages/CourseEditor/DefinitionStep/DefinitionStep.tsx
+++ b/frontend/src/pages/CourseEditor/DefinitionStep/DefinitionStep.tsx
@@ -54,8 +54,8 @@ const DefinitionStep: FC<IStepProps> = ({
               inputProps={{
                 maxLength: MAX_TITLE_LENGTH,
               }}
-              error={Boolean(formik.errors?.title)}
-              helperText={formik.errors?.title}
+              error={formik.touched.title && Boolean(formik.errors?.title)}
+              helperText={formik.touched.title && formik.errors?.title}
             />
             <InputLengthCounter>{`${formik.values.title.length}/${MAX_TITLE_LENGTH}`}</InputLengthCounter>
           </FieldWrapper>
@@ -108,8 +108,8 @@ const DefinitionStep: FC<IStepProps> = ({
               maxLength: MAX_DESCRIPTION_LENGTH,
             }}
             onChange={formik.handleChange}
-            error={Boolean(formik.errors?.description)}
-            helperText={formik.errors?.description}
+            error={formik.touched.description && Boolean(formik.errors?.description)}
+            helperText={formik.touched.description && formik.errors?.description}
           />
           <InputLengthCounter>{`${formik.values.description.length}/${MAX_DESCRIPTION_LENGTH}`}</InputLengthCounter>
         </DescriptionFieldWrapper>

--- a/frontend/src/pages/CourseEditor/DefinitionStep/styled.ts
+++ b/frontend/src/pages/CourseEditor/DefinitionStep/styled.ts
@@ -58,7 +58,7 @@ export const InputLengthCounter = styled(Typography)({
   alignSelf: 'flex-end',
   fontSize: '0.75rem',
   marginTop: '6px',
-  color: 'rgba(0, 0, 0, 0.23)',
+  color: '#A2A2A2',
 });
 
 export const DescriptionFieldWrapper = styled(FieldWrapper)({

--- a/frontend/src/pages/CourseEditor/LessonsStep/LessonItem/LessonItem.tsx
+++ b/frontend/src/pages/CourseEditor/LessonsStep/LessonItem/LessonItem.tsx
@@ -58,7 +58,11 @@ const LessonItem: FC<ILessonItemProps> = ({ formik, material, index, onFieldBlur
             <Field
               id={`materials[${index}].material`}
               name={`materials[${index}.material`}
-              placeholder={material.material}
+              placeholder={
+                material.type === ContentElementType.presentation
+                  ? 'Material presentation link'
+                  : 'Material video link'
+              }
               value={material.material}
               onChange={formik.handleChange}
               inputProps={{
@@ -82,6 +86,7 @@ const LessonItem: FC<ILessonItemProps> = ({ formik, material, index, onFieldBlur
               multiline
               id={`materials[${index}].material`}
               name={`materials[${index}.material`}
+              placeholder="Text material"
               value={material.material}
               onChange={formik.handleChange}
               onBlur={onFieldBlur}
@@ -102,7 +107,7 @@ const LessonItem: FC<ILessonItemProps> = ({ formik, material, index, onFieldBlur
           <Field
             id={`materials[${index}].exercise.title`}
             name={`materials[${index}].exercise.title`}
-            placeholder={material?.exercise?.title}
+            placeholder="Exercise title"
             value={material?.exercise?.title}
             onChange={formik.handleChange}
             onBlur={onFieldBlur}
@@ -122,6 +127,7 @@ const LessonItem: FC<ILessonItemProps> = ({ formik, material, index, onFieldBlur
         <InputTitle>{EditorTitles.exerciseDescription}</InputTitle>
         <TextField
           multiline
+          placeholder="Exercise description"
           id={`materials[${index}].exercise.task`}
           name={`materials[${index}].exercise.task`}
           value={material?.exercise?.task}

--- a/frontend/src/pages/CourseEditor/LessonsStep/LessonsStep.tsx
+++ b/frontend/src/pages/CourseEditor/LessonsStep/LessonsStep.tsx
@@ -35,7 +35,7 @@ const LessonsStep: FC<IStepProps> = ({ formik, courseData, isCourseDataLoading, 
                         if (formik.values.materials.length === Numbers.one) {
                           push({
                             type: 'video',
-                            material: 'Material video link',
+                            material: '',
                             exercise: {},
                           });
                         }
@@ -49,7 +49,7 @@ const LessonsStep: FC<IStepProps> = ({ formik, courseData, isCourseDataLoading, 
                         onClick={() =>
                           push({
                             type: 'video',
-                            material: 'Material video link',
+                            material: '',
                             exercise: {},
                           })
                         }

--- a/frontend/src/pages/CourseEditor/TestStep/QuestionItem/QuestionItem.tsx
+++ b/frontend/src/pages/CourseEditor/TestStep/QuestionItem/QuestionItem.tsx
@@ -2,7 +2,7 @@
 import { FC } from 'react';
 import { FieldArray } from 'formik';
 import { MenuItem, RadioGroup, Alert } from '@mui/material';
-import { Add } from '@mui/icons-material';
+import { Add, Remove } from '@mui/icons-material';
 
 import { BUTTON_VARIANT, EditorTitles, MAX_QUESTION_LENGTH } from 'constants/courseEditor';
 import { Numbers } from 'enums/numbers';
@@ -38,6 +38,7 @@ const QuestionItem: FC<IQuestionItemProps> = ({
     <QuestionInputBox>
       <FieldWrapper>
         <InputText
+          placeholder="Question title"
           value={question?.question}
           id={`questions[${index}].question`}
           name={`test.questions[${index}].question`}
@@ -69,7 +70,7 @@ const QuestionItem: FC<IQuestionItemProps> = ({
       onChange={handleChangeCorrectAnswer}
     >
       <FieldArray name={`test.questions[${index}].answers`}>
-        {({ push }) => (
+        {({ push, remove }) => (
           <>
             {question?.answers?.map((answer, key) => (
               <RadioControlLabel
@@ -78,6 +79,7 @@ const QuestionItem: FC<IQuestionItemProps> = ({
                 control={<RadioSelectAnswer color="primary" />}
                 label={
                   <InputAnswer
+                    placeholder="Answer"
                     variant="standard"
                     value={answer.variant}
                     id={`test.questions[${index}].answers[${key}].variant`}
@@ -109,6 +111,13 @@ const QuestionItem: FC<IQuestionItemProps> = ({
                 }
               >
                 <Add color="primary" fontSize="medium" />
+              </AddAnswerButton>
+              <AddAnswerButton
+                variant="mediumOutlined"
+                disabled={formik.errors.test?.questions[index]?.answers}
+                onClick={() => remove(index)}
+              >
+                <Remove color="primary" fontSize="medium" />
               </AddAnswerButton>
             </ButtonsWrapper>
           </>

--- a/frontend/src/pages/CourseEditor/TestStep/TestStep.tsx
+++ b/frontend/src/pages/CourseEditor/TestStep/TestStep.tsx
@@ -32,6 +32,7 @@ const TestStep: FC<IStepProps> = ({
         <ItemTitle>{EditorTitles.testDetails}</ItemTitle>
         <TestTitleBox>
           <TestBasicField
+            placeholder="Test title"
             label="Title"
             value={formik.values.test.title}
             id="test.title"
@@ -65,11 +66,11 @@ const TestStep: FC<IStepProps> = ({
                             question: 'Test question',
                             answers: [
                               {
-                                variant: 'Answer',
+                                variant: '',
                                 aN: Numbers.one,
                               },
                               {
-                                variant: 'Answer',
+                                variant: '',
                                 aN: Numbers.two,
                               },
                             ],
@@ -88,14 +89,14 @@ const TestStep: FC<IStepProps> = ({
                         }
                         onClick={() =>
                           push({
-                            question: 'Test question',
+                            question: '',
                             answers: [
                               {
-                                variant: 'Answer',
+                                variant: '',
                                 aN: Numbers.one,
                               },
                               {
-                                variant: 'Answer',
+                                variant: '',
                                 aN: Numbers.two,
                               },
                             ],


### PR DESCRIPTION
1. Fixed:  If the user clicks on the required field and then clicks on any place on the screen, the error will be displayed in all required fields
2  Fixed: Next button is disabled if  any error  in the fields on current step
3 Fixed the characters counter color #A2A2A2
4 Added  the minus for deleting the answer of the question
5 Added default  type value "Video" on the Lesson Step 
6  Added placeholders nn the Lessons step:  in the Video, Presentation, Text fields the placeholder should be displayed (Material video link, Material presentation link, Text material)
7 Added placeholders on the Test step In the question title and answers when the user opens the tab first time and when add new question