### PR TITLE
V1-269 Bugfix: changed exercise errors displaying

### DIFF
--- a/frontend/src/constants/courseEditor.ts
+++ b/frontend/src/constants/courseEditor.ts
@@ -144,6 +144,7 @@ export enum EditorTitles {
   lessonCount = 'Lesson № ',
   exerciseTitle = 'Exercise Title',
   exerciseDescription = 'Exercise Description',
+  exerciseHint = 'Exercise should contain both title and description',
   testDetails = 'Test details',
   questionNumber = 'Question № ',
 }

--- a/frontend/src/pages/CourseEditor/LessonsStep/LessonItem/LessonItem.tsx
+++ b/frontend/src/pages/CourseEditor/LessonsStep/LessonItem/LessonItem.tsx
@@ -1,8 +1,6 @@
 import { FC } from 'react';
 import { MenuItem, TextField } from '@mui/material';
 
-import { ILessonItemProps } from 'pages/CourseEditor/types';
-import { Numbers } from 'enums/numbers';
 import {
   LESSONS_TYPE,
   LESSONS_TYPE_TITLE_MAP,
@@ -11,8 +9,10 @@ import {
   MAX_MATERIAL_LENGTH,
   LESSONS_PLACEHOLDER_MAPPER,
 } from 'constants/courseEditor';
-import { Field, InputLengthCounter } from 'pages/CourseEditor/DefinitionStep/styled';
 import { ContentElementType } from 'enums/materials';
+import { Numbers } from 'enums/numbers';
+import { ILessonItemProps } from 'pages/CourseEditor/types';
+import { Field, InputLengthCounter } from 'pages/CourseEditor/DefinitionStep/styled';
 
 import {
   InputBox,
@@ -108,7 +108,10 @@ const LessonItem: FC<ILessonItemProps> = ({
             value={material?.exercise?.task}
             onChange={formik.handleChange}
             onBlur={onFieldBlur}
-            error={Boolean(formik.errors?.materials?.[index]?.exercise?.task)}
+            error={
+              formik.touched.materials?.[index]?.exercise?.task &&
+              Boolean(formik.errors?.materials?.[index]?.exercise?.task)
+            }
             helperText={formik.errors?.materials?.[index]?.exercise?.task}
           />
         </InputBox>
@@ -116,4 +119,5 @@ const LessonItem: FC<ILessonItemProps> = ({
     </LessonItemWrapper>
   );
 };
+
 export default LessonItem;

--- a/frontend/src/pages/CourseEditor/LessonsStep/LessonItem/styled.ts
+++ b/frontend/src/pages/CourseEditor/LessonsStep/LessonItem/styled.ts
@@ -26,7 +26,7 @@ export const InputBox = styled(Box)({
 });
 
 export const InputTitle = styled(Typography)({
-  margin: '40px 0 30px',
+  margin: '40px 0 20px',
   fontWeight: 400,
   fontSize: '22px',
   lineHeight: '29px',
@@ -45,3 +45,10 @@ export const MaterialFieldWrapper = styled(FieldWrapper)<IMaterialFieldWrapper>(
     }),
   }),
 );
+
+export const TaskHint = styled(Typography)({
+  margin: '6px 0',
+  verticalAlign: 'bottom',
+  fontSize: '12px',
+  color: '#A2A2A2',
+});

--- a/frontend/src/validations/schemas/courseEditorValidationSchema.ts
+++ b/frontend/src/validations/schemas/courseEditorValidationSchema.ts
@@ -99,8 +99,7 @@ const courseEditorValidationSchema = object().shape({
               )
               .when('task', {
                 is: (value: string) => value !== '' && value !== undefined && value !== null,
-                then: (scheme) =>
-                  scheme.required('Exercise should contain both title and description'),
+                then: (scheme) => scheme.required('Exercise title is required'),
                 otherwise: (scheme) => scheme.optional(),
               }),
             task: string()
@@ -119,8 +118,7 @@ const courseEditorValidationSchema = object().shape({
               )
               .when('title', {
                 is: (value: string) => value !== '' && value !== undefined && value !== null,
-                then: (scheme) =>
-                  scheme.required('Exercise should contain both title and description'),
+                then: (scheme) => scheme.required('Exercise description is required'),
                 otherwise: (scheme) => scheme.optional(),
               }),
           },


### PR DESCRIPTION
**Fixed the following issue:**

The error next to the Exercise description field is displayed when the admin starts typing in the Exercise title field. There should be a hint under the Exercise Description field "Exercise should contain both title and description" in color #A2A2A2